### PR TITLE
Use precise GBP prices and enforce catalog validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,38 @@ jobs:
       - name: Cleanup disposable CI resources
         if: always()
         run: docker compose --env-file backend/.env down --volumes
+  postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: ecommerce
+          POSTGRES_PASSWORD: ci-only-password
+          POSTGRES_DB: ecommerce_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ecommerce -d ecommerce_test"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.22"
+          enable-cache: true
+      - run: uv sync --locked --python 3.12
+      - name: Create separate disposable migration database
+        run: |
+          uv run python - <<'PY'
+          import psycopg
+          with psycopg.connect("postgresql://ecommerce:ci-only-password@localhost:5432/ecommerce_test", autocommit=True) as connection:
+              connection.execute("CREATE DATABASE ecommerce_migrations")
+          PY
+      - run: uv run pytest -q
+        env:
+          TEST_DATABASE_URL: postgresql+psycopg://ecommerce:ci-only-password@localhost:5432/ecommerce_test
+          TEST_MIGRATION_DATABASE_URL: postgresql+psycopg://ecommerce:ci-only-password@localhost:5432/ecommerce_migrations

--- a/backend/README.md
+++ b/backend/README.md
@@ -47,3 +47,27 @@ To refresh the pip compatibility export after changing dependencies:
 ```sh
 uv export --locked --no-dev --no-emit-project --format requirements-txt --output-file requirements.txt
 ```
+
+## Product contract
+
+The launch currency is GBP. Products return `price` as a two-place decimal string
+(for example `"19.90"`) and `currency: "GBP"`. Create requests may omit currency;
+other currencies are rejected. Prices range from 0.00 to 9999999999.99 and may have
+at most two decimal places. Stock is an integer from 0 to 2147483647. Names are
+trimmed and must contain 1–255 characters; descriptions allow up to 10,000.
+
+PUT retains its existing partial-update behavior: omitted fields are preserved.
+Only description may explicitly be null. Unknown fields are rejected. Product
+lists are ordered by id; skip is 0–100000 and limit is 1–100 (default 10).
+
+Migration 0002 labels existing prices GBP, changes storage to NUMERIC(12, 2), and
+adds constraints. It requires an online database connection and checks existing
+data before DDL, refusing invalid rows or
+prices that require rounding. Back up existing databases and correct flagged rows
+before retrying. Downgrading restores legacy float storage and removes currency;
+it is intended for disposable tests, not as a substitute for a production rollback
+and backup plan.
+
+CI runs the tests against both SQLite and PostgreSQL. TEST_DATABASE_URL and
+TEST_MIGRATION_DATABASE_URL are test-only overrides that must name two distinct,
+disposable databases: these tests create/drop tables and exercise downgrades.

--- a/backend/alembic/versions/0002_product_money_constraints.py
+++ b/backend/alembic/versions/0002_product_money_constraints.py
@@ -1,0 +1,95 @@
+"""Store GBP prices as decimals and enforce catalog invariants."""
+
+from decimal import Decimal, InvalidOperation
+
+import sqlalchemy as sa
+
+from alembic import context, op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if context.is_offline_mode():
+        raise RuntimeError(
+            "Migration 0002 requires an online connection for legacy-data validation"
+        )
+    connection = op.get_bind()
+    if connection.dialect.name == "postgresql":
+        connection.execute(sa.text("LOCK TABLE products IN ACCESS EXCLUSIVE MODE"))
+    # Refuse lossy conversions before issuing DDL. Operators must correct invalid
+    # legacy data deliberately; this migration never rounds or deletes products.
+    rows = connection.execute(
+        sa.text("SELECT id, name, description, price, stock FROM products")
+    )
+    for row in rows.mappings():
+        try:
+            price = Decimal(str(row["price"]))
+            valid_price = (
+                price.is_finite()
+                and 0 <= price <= Decimal("9999999999.99")
+                and price == price.quantize(Decimal("0.01"))
+            )
+        except InvalidOperation:
+            valid_price = False
+        if (
+            not valid_price
+            or row["stock"] is None
+            or not 0 <= row["stock"] <= 2147483647
+            or not row["name"].strip()
+            or len(row["name"]) > 255
+            or (row["description"] is not None and len(row["description"]) > 10000)
+        ):
+            raise ValueError(
+                f"Product {row['id']} needs correction before migration 0002; no data was changed"
+            )
+
+    with op.batch_alter_table("products") as batch:
+        batch.alter_column(
+            "price",
+            existing_type=sa.Float(),
+            type_=sa.Numeric(12, 2),
+            existing_nullable=False,
+        )
+        batch.alter_column("stock", existing_type=sa.Integer(), nullable=False)
+        batch.add_column(
+            sa.Column("currency", sa.String(3), nullable=False, server_default="GBP")
+        )
+        batch.create_check_constraint(
+            "ck_products_price_range", "price >= 0 AND price <= 9999999999.99"
+        )
+        batch.create_check_constraint(
+            "ck_products_stock_range", "stock >= 0 AND stock <= 2147483647"
+        )
+        batch.create_check_constraint("ck_products_currency", "currency = 'GBP'")
+        batch.create_check_constraint(
+            "ck_products_name_length", "length(trim(name)) >= 1 AND length(name) <= 255"
+        )
+        batch.create_check_constraint(
+            "ck_products_description_length",
+            "description IS NULL OR length(description) <= 10000",
+        )
+
+
+def downgrade():
+    # Downgrade returns to legacy floating-point storage and removes currency.
+    with op.batch_alter_table("products") as batch:
+        for name in (
+            "ck_products_price_range",
+            "ck_products_stock_range",
+            "ck_products_currency",
+            "ck_products_name_length",
+            "ck_products_description_length",
+        ):
+            batch.drop_constraint(name, type_="check")
+        batch.drop_column("currency")
+        batch.alter_column("stock", existing_type=sa.Integer(), nullable=True)
+        batch.alter_column(
+            "price",
+            existing_type=sa.Numeric(12, 2),
+            type_=sa.Float(),
+            existing_nullable=False,
+        )

--- a/backend/app/api/v1/products.py
+++ b/backend/app/api/v1/products.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import require_admin
@@ -18,7 +18,11 @@ router = APIRouter()
 
 
 @router.get("/", response_model=List[ProductRead])
-def read_products(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+def read_products(
+    skip: int = Query(default=0, ge=0, le=100000),
+    limit: int = Query(default=10, ge=1, le=100),
+    db: Session = Depends(get_db),
+):
     return get_products(db=db, skip=skip, limit=limit)
 
 

--- a/backend/app/crud/product.py
+++ b/backend/app/crud/product.py
@@ -7,7 +7,7 @@ from app.schemas.product import ProductCreate, ProductUpdate
 
 
 def get_products(db: Session, skip: int = 0, limit: int = 10) -> List[Product]:
-    return db.query(Product).offset(skip).limit(limit).all()
+    return db.query(Product).order_by(Product.id).offset(skip).limit(limit).all()
 
 
 def get_product(db: Session, product_id: int) -> Optional[Product]:

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -1,16 +1,43 @@
-from sqlalchemy import Column, DateTime, Float, Integer, String, Text, func
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    func,
+)
 
 from app.models.base import Base
 
 
 class Product(Base):
     __tablename__ = "products"
+    __table_args__ = (
+        CheckConstraint(
+            "price >= 0 AND price <= 9999999999.99", name="ck_products_price_range"
+        ),
+        CheckConstraint(
+            "stock >= 0 AND stock <= 2147483647", name="ck_products_stock_range"
+        ),
+        CheckConstraint("currency = 'GBP'", name="ck_products_currency"),
+        CheckConstraint(
+            "length(trim(name)) >= 1 AND length(name) <= 255",
+            name="ck_products_name_length",
+        ),
+        CheckConstraint(
+            "description IS NULL OR length(description) <= 10000",
+            name="ck_products_description_length",
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(255), nullable=False, index=True)
     description = Column(Text, nullable=True)
-    price = Column(Float, nullable=False)
-    stock = Column(Integer, default=0)
+    price = Column(Numeric(12, 2), nullable=False)
+    currency = Column(String(3), nullable=False, default="GBP", server_default="GBP")
+    stock = Column(Integer, nullable=False, default=0)
     created_at = Column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -1,13 +1,40 @@
-from typing import Optional
+from decimal import Decimal
+from typing import Annotated, Literal, Self
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_serializer,
+    model_validator,
+)
+
+ProductName = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)
+]
+Price = Annotated[
+    Decimal,
+    Field(
+        ge=0,
+        le=Decimal("9999999999.99"),
+        max_digits=12,
+        decimal_places=2,
+        allow_inf_nan=False,
+    ),
+]
+Stock = Annotated[int, Field(ge=0, le=2147483647, strict=True)]
+Description = Annotated[str, Field(max_length=10000)]
+Currency = Literal["GBP"]
 
 
 class ProductBase(BaseModel):
-    name: str
-    description: Optional[str] = None
-    price: float
-    stock: int
+    model_config = ConfigDict(extra="forbid")
+    name: ProductName
+    description: Description | None = None
+    price: Price
+    currency: Currency = "GBP"
+    stock: Stock
 
 
 class ProductCreate(ProductBase):
@@ -15,13 +42,25 @@ class ProductCreate(ProductBase):
 
 
 class ProductUpdate(BaseModel):
-    name: Optional[str] = None
-    description: Optional[str] = None
-    price: Optional[float] = None
-    stock: Optional[int] = None
+    model_config = ConfigDict(extra="forbid")
+    name: ProductName | None = None
+    description: Description | None = None
+    price: Price | None = None
+    currency: Currency | None = None
+    stock: Stock | None = None
+
+    @model_validator(mode="after")
+    def reject_null_required_fields(self) -> Self:
+        for field in ("name", "price", "currency", "stock"):
+            if field in self.model_fields_set and getattr(self, field) is None:
+                raise ValueError(f"{field} cannot be null")
+        return self
 
 
 class ProductRead(ProductBase):
     id: int
-    # Pydantic v2: use ConfigDict(from_attributes=True) to allow ORM objects
     model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer("price", when_used="json")
+    def serialize_price(self, price: Decimal) -> str:
+        return format(price, ".2f")

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -17,12 +17,17 @@ from app.models.base import Base
 
 @pytest.fixture
 def db():
-    engine = create_engine(
-        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    url = os.environ.get("TEST_DATABASE_URL", "sqlite://")
+    options = (
+        {"connect_args": {"check_same_thread": False}, "poolclass": StaticPool}
+        if url == "sqlite://"
+        else {}
     )
+    engine = create_engine(url, **options)
     Base.metadata.create_all(engine)
     with Session(engine) as session:
         yield session
+    Base.metadata.drop_all(engine)
     engine.dispose()
 
 

--- a/backend/app/tests/test_migrations.py
+++ b/backend/app/tests/test_migrations.py
@@ -9,7 +9,9 @@ BACKEND = Path(__file__).resolve().parents[2]
 
 
 def test_migration_upgrade_downgrade_and_metadata(tmp_path):
-    database_url = f"sqlite:///{tmp_path / 'migration.db'}"
+    database_url = os.environ.get(
+        "TEST_MIGRATION_DATABASE_URL", f"sqlite:///{tmp_path / 'migration.db'}"
+    )
     env = dict(os.environ, DATABASE_URL=database_url)
 
     def alembic(*args):
@@ -31,4 +33,60 @@ def test_migration_upgrade_downgrade_and_metadata(tmp_path):
     assert "users" not in inspect(engine).get_table_names()
     alembic("upgrade", "head")
     alembic("check")
+    engine.dispose()
+
+
+# TEST_MIGRATION_DATABASE_URL, when set, must point to a separate disposable DB.
+def test_existing_product_migration_preserves_money_and_rejects_loss(tmp_path):
+    from decimal import Decimal
+
+    from sqlalchemy import MetaData, Table, text
+
+    url = os.environ.get(
+        "TEST_MIGRATION_DATABASE_URL", f"sqlite:///{tmp_path / 'legacy.db'}"
+    )
+    env = dict(os.environ, DATABASE_URL=url)
+
+    def migrate(*args, check=True):
+        return subprocess.run(
+            [sys.executable, "-m", "alembic", *args],
+            cwd=BACKEND,
+            env=env,
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+    # Only the dedicated disposable migration DB is reset here.
+    migrate("downgrade", "base")
+    migrate("upgrade", "0001")
+    engine = create_engine(url)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO products (name, price, stock) VALUES ('Legacy', 19.99, 4)"
+            )
+        )
+    migrate("upgrade", "head")
+    table = Table("products", MetaData(), autoload_with=engine)
+    with engine.connect() as connection:
+        product = connection.execute(table.select()).mappings().one()
+        assert product["price"] == Decimal("19.99")
+        assert product["currency"] == "GBP"
+        assert product["stock"] == 4
+    migrate("check")
+    migrate("downgrade", "0001")
+    with engine.begin() as connection:
+        connection.execute(text("UPDATE products SET price=1.234"))
+    failed = migrate("upgrade", "head", check=False)
+    assert failed.returncode != 0
+    assert "needs correction" in failed.stderr
+    assert "currency" not in {
+        column["name"] for column in inspect(engine).get_columns("products")
+    }
+    with engine.connect() as connection:
+        assert (
+            connection.execute(text("SELECT price FROM products")).scalar_one() == 1.234
+        )
+    migrate("downgrade", "base")
     engine.dispose()

--- a/backend/app/tests/test_products.py
+++ b/backend/app/tests/test_products.py
@@ -40,3 +40,154 @@ def test_catalog_is_public(client, db):
     assert client.get("/api/v1/products/").status_code == 200
     assert client.get(f"/api/v1/products/{product.id}").json()["name"] == "Public"
     assert client.get("/api/v1/products/99999").status_code == 404
+
+
+@pytest.fixture
+def admin_headers(user, token, db):
+    user.is_superuser = True
+    db.commit()
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        {"name": ""},
+        {"name": "   "},
+        {"name": "a" * 256},
+        {"price": "-0.01"},
+        {"price": "1.001"},
+        {"price": "NaN"},
+        {"price": "Infinity"},
+        {"price": "10000000000.00"},
+        {"stock": -1},
+        {"stock": 2147483648},
+        {"stock": 1.5},
+        {"stock": True},
+        {"currency": "USD"},
+        {"currency": "gbp"},
+        {"name": None},
+        {"price": None},
+        {"stock": None},
+        {"currency": None},
+        {"description": "x" * 10001},
+        {"unknown": "value"},
+    ],
+)
+def test_invalid_product_create(client, admin_headers, db, invalid):
+    payload = {"name": "Valid", "price": "12.34", "stock": 1, **invalid}
+    response = client.post("/api/v1/products/", json=payload, headers=admin_headers)
+    assert response.status_code == 422
+    assert db.query(Product).count() == 0
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        {"name": None},
+        {"price": None},
+        {"stock": None},
+        {"currency": None},
+        {"name": " "},
+        {"stock": -1},
+        {"price": "12.345"},
+        {"currency": "EUR"},
+    ],
+)
+def test_invalid_product_update_preserves_record(client, admin_headers, db, invalid):
+    product = Product(name="Original", price=12.34, stock=2)
+    db.add(product)
+    db.commit()
+    response = client.put(
+        f"/api/v1/products/{product.id}", json=invalid, headers=admin_headers
+    )
+    assert response.status_code == 422
+    db.refresh(product)
+    assert product.name == "Original"
+    assert product.stock == 2
+    assert str(product.price) == "12.34"
+
+
+def test_decimal_price_roundtrip_and_partial_update(client, admin_headers):
+    created = client.post(
+        "/api/v1/products/",
+        headers=admin_headers,
+        json={"name": "  Tea  ", "price": "19.90", "stock": 2, "description": "Box"},
+    )
+    assert created.status_code == 201
+    product = created.json()
+    assert product["name"] == "Tea"
+    assert product["price"] == "19.90"
+    assert product["currency"] == "GBP"
+    url = f"/api/v1/products/{product['id']}"
+    response = client.put(url, json={"description": None}, headers=admin_headers)
+    assert response.status_code == 200
+    assert response.json()["description"] is None
+    assert response.json()["price"] == "19.90"
+    assert client.get(url).json()["currency"] == "GBP"
+    assert client.delete(url, headers=admin_headers).status_code == 204
+    assert client.get(url).status_code == 404
+
+
+@pytest.mark.parametrize(
+    "query", ["skip=-1", "skip=100001", "limit=0", "limit=-1", "limit=101"]
+)
+def test_pagination_bounds(client, query):
+    assert client.get(f"/api/v1/products/?{query}").status_code == 422
+
+
+def test_pagination_is_ordered(client, db):
+    for index in range(3):
+        db.add(Product(name=f"Product {index}", price=0, stock=0))
+    db.commit()
+    page = client.get("/api/v1/products/?skip=1&limit=1").json()
+    assert len(page) == 1
+    assert page[0]["name"] == "Product 1"
+    assert page[0]["price"] == "0.00"
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"name": "   "},
+        {"name": "x" * 256},
+        {"price": -1},
+        {"stock": -1},
+        {"stock": 2147483648},
+        {"currency": "USD"},
+        {"description": "x" * 10001},
+    ],
+)
+def test_database_constraints_reject_invalid_writes(db, values):
+    from sqlalchemy import insert
+    from sqlalchemy.exc import DataError, IntegrityError
+
+    with pytest.raises((IntegrityError, DataError)):
+        db.execute(
+            insert(Product).values(
+                {"name": "Valid", "price": 1, "stock": 1, "currency": "GBP", **values}
+            )
+        )
+        db.commit()
+    db.rollback()
+
+
+@pytest.mark.parametrize("field", ["name", "price", "stock", "currency"])
+def test_database_required_columns(db, field):
+    from sqlalchemy import insert
+    from sqlalchemy.exc import IntegrityError
+
+    with pytest.raises(IntegrityError):
+        db.execute(
+            insert(Product).values(
+                {
+                    "name": "Valid",
+                    "price": 1,
+                    "stock": 1,
+                    "currency": "GBP",
+                    field: None,
+                }
+            )
+        )
+        db.commit()
+    db.rollback()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,8 +6,9 @@ SQLite is used for isolated unit/API tests. Alembic controls database schema.
 
 The frontend/ directory provides a Next.js skeleton and scoped agent guidance.
 The browser application, cart, orders, and payment adapters are not implemented.
-Existing files for those domains are placeholders. Product money still uses Float;
-conversion and database constraints are the next catalog task.
+Existing files for those domains are placeholders. Product prices use Decimal /
+NUMERIC(12, 2), carry GBP currency, and serialize as two-place decimal strings.
+API validation and database constraints protect catalog values.
 
 The initial development stack has PostgreSQL, a one-shot migration container, and
 the API. The API starts only after migrations succeed. It runs as a non-root user.

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -14,10 +14,8 @@
 
 ## Next PRs, in dependency order
 
-1. Catalog correctness: replace Float money with a chosen explicit currency/minor-unit
-   or decimal representation, preserve existing values through a reviewed migration,
-   bound pagination, validate names/stock/prices, and add DB constraints. Prove
-   invalid/null updates fail and valid CRUD works for admins.
+1. Catalog correctness is implemented: GBP decimal prices, bounded pagination,
+   request validation, database constraints, and legacy-data migration checks.
 2. Admin bootstrap: an explicit command to create/promote the first admin without
    hardcoded credentials; verify idempotence and prevent accidental password reset.
 3. Next.js catalog: App Router, TypeScript, locked runtime, generated OpenAPI client,


### PR DESCRIPTION
Product writes previously accepted negative stock/prices, invalid null updates, and unbounded pagination, while money used floating-point storage. Products now store NUMERIC(12, 2), return two-place decimal strings with GBP currency, and enforce request and database constraints. GBP is the owner's selected launch currency; other currencies are rejected.

Adds stable id-ordered pagination (limit 1–100, skip 0–100000), trimmed names, bounded descriptions/stock, rejection of unknown fields, and explicit null handling for partial PUT updates. Migration 0002 validates existing records before DDL, preserves valid prices, labels them GBP, and refuses values requiring rounding or correction. PostgreSQL locks the product table during preflight/conversion; this is an online migration.

Evidence: the regression suite exposed 31 failures against the old implementation. All 70 tests now pass locally on SQLite. CI adds a dedicated PostgreSQL job running the full suite plus legacy-data conversion and refusal checks; existing container smoke and rollback checks remain required before merge.

Compatibility: price responses change from JSON numbers to strings. Currency is GBP by default and returned explicitly. PUT remains partial; description alone can be null. Downgrading returns to legacy float storage and drops currency, so production adoption needs a backup/rollback plan. No production databases are touched by this PR.
