### PR TITLE
Add reproducible demo catalog and safe admin bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 The current product is a FastAPI backend. The frontend/ directory is a Next.js
 skeleton; the runnable storefront and checkout flow are still planned. Read
-docs/architecture.md and docs/plans/roadmap.md before choosing work; update their
+docs/plans/portfolio.md, docs/architecture.md, and docs/plans/roadmap.md before choosing work; update their
 factual status when a feature lands.
 
 ## Commands

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,10 @@ hooks-check:
 
 requirements-check:
 	python3 backend/scripts/check_requirements.py
+
+.PHONY: demo admin
+demo:
+	cd backend && uv run python -m app.bootstrap seed-demo --confirm-demo
+
+admin:
+	cd backend && uv run python -m app.bootstrap admin --email "$(EMAIL)"

--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ Stock must be a nonnegative integer. Lists use a stable id order, a limit of 1â€
 description may explicitly be null. Unsupported currencies and unknown fields
 are rejected. See [backend documentation](backend/README.md) for full constraints.
 
-An admin bootstrap command is still planned. Product management is tested using
-isolated admin fixtures; there is no default admin password or public promotion route.
+Run `make demo` to populate an empty catalog, then `make admin EMAIL=admin@example.com`
+to create an admin with a hidden password prompt. See the [demo guide](docs/demo.md)
+for rerun and promotion behavior. There is no default admin password or public promotion route.
 
 ## Database migrations
 
@@ -194,7 +195,8 @@ will define region, costs, identities/secrets, registry, networking, logs,
 backup/restore, and rollback before provisioning. The old AWS Terraform in
 `backend/infra` is legacy reference, not the deployment path.
 
-The next product steps are admin bootstrap, a runnable catalog frontend, customer
+This is a [senior SWE portfolio project](docs/plans/portfolio.md).
+The next product steps are a runnable catalog frontend, customer
 sessions, carts, orders, and sandbox payments. Follow the
 [ordered roadmap](docs/plans/roadmap.md) for the remaining work.
 

--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -1,0 +1,110 @@
+"""Explicit operator commands for a disposable portfolio demo database."""
+
+import argparse
+from getpass import getpass
+
+from pydantic import ValidationError
+from sqlalchemy import select, text
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.core.security import get_password_hash
+from app.db.session import SessionLocal
+from app.models.product import Product
+from app.models.user import User
+from app.schemas.product import ProductCreate
+from app.schemas.user import UserBase, UserCreate
+
+DEMO_PRODUCTS = (
+    ("Oak Monitor Stand", "Fictional solid-oak desk riser.", "79.00", 12),
+    ("Felt Desk Mat", "Fictional charcoal felt workspace mat.", "29.50", 24),
+    ("Task Light", "Fictional adjustable warm-white desk lamp.", "65.00", 8),
+    ("Cable Tray", "Fictional under-desk cable organiser.", "24.00", 18),
+    ("Notebook Set", "Fictional set of three dotted notebooks.", "12.90", 30),
+    ("Ceramic Pen Cup", "Fictional hand-finished stationery holder.", "18.00", 0),
+)
+
+
+def seed_demo(db):
+    """Populate only an empty catalog; never overwrite or replenish existing data."""
+    if db.get_bind().dialect.name == "postgresql":
+        db.execute(text("LOCK TABLE products IN SHARE ROW EXCLUSIVE MODE"))
+    if db.scalar(select(Product.id).limit(1)) is not None:
+        return 0
+    for name, description, price, stock in DEMO_PRODUCTS:
+        data = ProductCreate(
+            name=name, description=description, price=price, stock=stock, currency="GBP"
+        )
+        db.add(Product(**data.model_dump()))
+    db.flush()
+    return len(DEMO_PRODUCTS)
+
+
+def ensure_admin(db, email, password=None, *, promote_existing=False):
+    email = str(UserBase(email=email).email)
+    user = db.scalar(select(User).where(User.email == email).with_for_update())
+    if user is not None:
+        if not user.is_active:
+            raise ValueError("Disabled accounts cannot be bootstrapped.")
+        if user.is_superuser:
+            return "Admin already exists; credentials unchanged."
+        if not promote_existing:
+            raise ValueError("Existing customer requires --promote-existing.")
+        user.is_superuser = True
+        db.flush()
+        return "Existing account promoted; credentials unchanged."
+    if promote_existing:
+        raise ValueError("No existing account to promote.")
+    data = UserCreate(email=email, password=password)
+    db.add(
+        User(
+            email=str(data.email),
+            hashed_password=get_password_hash(data.password),
+            is_active=True,
+            is_superuser=True,
+        )
+    )
+    db.flush()
+    return "Admin created."
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    seed = commands.add_parser("seed-demo")
+    seed.add_argument("--confirm-demo", action="store_true", required=True)
+    admin = commands.add_parser("admin")
+    admin.add_argument("--email", required=True)
+    admin.add_argument("--promote-existing", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        with SessionLocal.begin() as db:
+            if args.command == "seed-demo":
+                count = seed_demo(db)
+                message = (
+                    f"Created {count} demo products; existing catalogs are preserved."
+                )
+            else:
+                email = str(UserBase(email=args.email).email)
+                existing = db.scalar(select(User.id).where(User.email == email))
+                password = None
+                if existing is None and not args.promote_existing:
+                    password = getpass("New admin password (8–128 characters): ")
+                    if password != getpass("Confirm password: "):
+                        raise ValueError("Passwords do not match.")
+                message = ensure_admin(
+                    db, email, password, promote_existing=args.promote_existing
+                )
+        print(message)
+    except ValidationError:
+        parser.exit(1, "Invalid email or password (must be 8–128 characters).\n")
+    except (ValueError, EOFError) as exc:
+        parser.exit(1, f"Bootstrap refused: {exc}\n")
+    except SQLAlchemyError:
+        parser.exit(
+            1,
+            "Database operation failed; transaction rolled back. Check migrations and connection.\n",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/tests/test_bootstrap.py
+++ b/backend/app/tests/test_bootstrap.py
@@ -1,0 +1,117 @@
+import pytest
+from sqlalchemy import func, select
+
+from app import bootstrap
+from app.core.security import verify_password
+from app.models.product import Product
+from app.models.user import User
+
+
+def test_seed_preserves_edits_and_does_not_duplicate(db):
+    assert bootstrap.seed_demo(db) == 6
+    db.commit()
+    product = db.scalar(select(Product).order_by(Product.id))
+    product.name = "Edited name"
+    product.stock = 1
+    db.commit()
+    assert bootstrap.seed_demo(db) == 0
+    assert db.scalar(select(func.count()).select_from(Product)) == 6
+    assert product.stock == 1
+    assert product.name == "Edited name"
+    assert all(p.currency == "GBP" for p in db.scalars(select(Product)))
+
+
+def test_seed_preserves_unrelated_catalog(db):
+    db.add(Product(name="Existing", price="1.00", stock=2, currency="GBP"))
+    db.commit()
+    assert bootstrap.seed_demo(db) == 0
+    assert db.scalar(select(func.count()).select_from(Product)) == 1
+
+
+def test_admin_creation_and_rerun_preserve_password(db):
+    bootstrap.ensure_admin(db, "admin@example.com", "original-password")
+    db.commit()
+    bootstrap.ensure_admin(db, "admin@example.com", "different-password")
+    user = db.scalar(select(User))
+    assert user.is_active and user.is_superuser
+    assert verify_password("original-password", user.hashed_password)
+    assert db.scalar(select(func.count()).select_from(User)) == 1
+
+
+def test_promotion_is_explicit_and_preserves_credentials(db, user):
+    original = user.hashed_password
+    with pytest.raises(ValueError, match="promote-existing"):
+        bootstrap.ensure_admin(db, user.email)
+    assert not user.is_superuser
+    bootstrap.ensure_admin(db, user.email, promote_existing=True)
+    assert user.is_superuser
+    assert user.hashed_password == original
+    user.is_active = False
+    with pytest.raises(ValueError, match="Disabled"):
+        bootstrap.ensure_admin(db, user.email, promote_existing=True)
+    assert not user.is_active
+
+
+def test_missing_promotion_target_and_invalid_credentials(db):
+    with pytest.raises(ValueError, match="No existing"):
+        bootstrap.ensure_admin(db, "absent@example.com", promote_existing=True)
+    with pytest.raises(ValueError):
+        bootstrap.ensure_admin(db, "invalid", "password123")
+    with pytest.raises(ValueError):
+        bootstrap.ensure_admin(db, "admin@example.com", "short")
+    assert db.scalar(select(func.count()).select_from(User)) == 0
+
+
+def test_cli_transactions_and_login(db, client, monkeypatch, capsys):
+    # Reuse the disposable test engine, including PostgreSQL in CI.
+    from sqlalchemy.orm import sessionmaker
+
+    monkeypatch.setattr(bootstrap, "SessionLocal", sessionmaker(bind=db.get_bind()))
+    monkeypatch.setattr(bootstrap, "getpass", lambda _: "demo-password123")
+    bootstrap.main(["seed-demo", "--confirm-demo"])
+    bootstrap.main(["admin", "--email", "admin@example.com"])
+    bootstrap.main(["admin", "--email", "admin@example.com"])
+    response = client.post(
+        "/api/v1/auth/login",
+        data={"username": "admin@example.com", "password": "demo-password123"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    result = client.post(
+        "/api/v1/products/",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"name": "Admin product", "price": "1.20", "stock": 1},
+    )
+    assert result.status_code == 201
+    assert "demo-password123" not in capsys.readouterr().out
+
+
+def test_cli_refusal_and_password_redaction(db, monkeypatch, capsys):
+    from sqlalchemy.orm import sessionmaker
+
+    monkeypatch.setattr(bootstrap, "SessionLocal", sessionmaker(bind=db.get_bind()))
+    monkeypatch.setattr(bootstrap, "getpass", lambda _: "short")
+    with pytest.raises(SystemExit):
+        bootstrap.main(["admin", "--email", "admin@example.com"])
+    assert "short" not in capsys.readouterr().err
+    assert db.scalar(select(func.count()).select_from(User)) == 0
+    with pytest.raises(SystemExit):
+        bootstrap.main(["seed-demo"])
+
+
+def test_cli_rolls_back_partial_seed(db, monkeypatch, capsys):
+    from sqlalchemy.exc import SQLAlchemyError
+    from sqlalchemy.orm import sessionmaker
+
+    monkeypatch.setattr(bootstrap, "SessionLocal", sessionmaker(bind=db.get_bind()))
+
+    def failed_seed(session):
+        session.add(Product(name="Partial", price="1.00", stock=1, currency="GBP"))
+        session.flush()
+        raise SQLAlchemyError("sensitive database details")
+
+    monkeypatch.setattr(bootstrap, "seed_demo", failed_seed)
+    with pytest.raises(SystemExit):
+        bootstrap.main(["seed-demo", "--confirm-demo"])
+    assert db.scalar(select(func.count()).select_from(Product)) == 0
+    assert "sensitive" not in capsys.readouterr().err

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,43 @@
+# Reproducible portfolio demo
+
+Use a disposable local database. This is a fictional desk-accessories shop with
+GBP prices, including an out-of-stock product for frontend empty-stock states.
+
+From the repository root:
+
+```sh
+make dev
+make demo
+make admin EMAIL=admin@example.com
+```
+
+The admin command prompts twice for a private password (8–128 characters). There
+is no shared default password, command-line password option, or generated secret
+in output. Use the account in `/docs` through the login endpoint. Public signup
+cannot grant admin access. The storefront is the next implementation step.
+
+`make demo` seeds six products only when the catalog is empty. Reruns leave all
+existing products untouched, including changed names, prices and depleted stock.
+A partially populated catalog is also left untouched; this is not a repair or
+reset command. It creates no users and never deletes data. PostgreSQL serializes
+seeding with a product-table write lock for the short transaction.
+
+`make admin` creates a new active admin, or leaves an existing active admin and
+its password unchanged. Existing customers require explicit promotion:
+
+```sh
+cd backend
+uv run python -m app.bootstrap admin --email admin@example.com --promote-existing
+```
+
+Promotion preserves the existing password. Disabled accounts are refused; an
+unknown promotion target is refused. There is no password-reset operation.
+Concurrent attempts to create the same email are protected by the unique database
+constraint; a losing operation rolls back and can be rerun.
+
+Commands use backend/.env's host DATABASE_URL, so migrations must already be
+applied and any DB_PORT change must be reflected there. They do not create tables
+or migrate automatically. All writes in each command commit together or roll back.
+For direct seeding use `uv run python -m app.bootstrap seed-demo --confirm-demo`
+from backend/. The flag acknowledges fictional demo data; it does not detect a
+production database. Never point this command at data you want to treat as live.

--- a/docs/plans/portfolio.md
+++ b/docs/plans/portfolio.md
@@ -1,0 +1,31 @@
+# Senior SWE portfolio plan
+
+This is an interview showcase, not a real business. Build a polished, reproducible
+fictional desk-accessories shop with decisions and evidence the owner can explain.
+GBP is the currency; Azure is the hosting target. Use a modular monolith and add
+infrastructure only for a demonstrated need. Deliver focused, reviewed PRs.
+
+## Delivery sequence
+
+1. Reproducible demo: fictional catalog and explicit, safe admin bootstrap.
+2. Polished Next.js/TypeScript storefront: responsive catalog/detail pages,
+   accessibility, loading/empty/error states, API contract and frontend CI.
+3. Complete sign-in → cart → checkout → confirmation across frontend/backend.
+4. Prove commerce correctness: server-owned prices, atomic inventory, checkout
+   idempotency, and concurrent attempts to buy the last item. Implement these
+   protections with checkout, not as a later patch. Add sandbox payments afterward.
+5. Azure demo: infrastructure as code, managed secrets, logs, health checks,
+   deployment/rollback documentation. Agree spending limits before provisioning.
+6. Interview package: architecture diagram, decision records with alternatives,
+   test evidence, and a five-minute demonstration walkthrough.
+
+## Success criteria
+
+A reviewer can run the demo without editing code, navigate a coherent shopping
+journey, and inspect evidence for important failure cases. Explain tradeoffs,
+limits, and how the design would evolve at scale. Avoid infrastructure added just
+for its name. No real payment details or customer data belong in this demo.
+
+See [roadmap](roadmap.md) for implemented status and remaining PRs. Keep this plan
+and the roadmap consistent when priorities change. Dependency proposals are
+reviewed separately; failing bot PRs are not a prerequisite to unrelated work.

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -1,5 +1,7 @@
 # Delivery roadmap
 
+Purpose and priorities: [senior SWE portfolio plan](portfolio.md).
+
 ## Landed foundation
 
 - Authentication repair, active-user/admin checks, bcrypt compatibility, and 22 regression tests (PR #1).
@@ -18,8 +20,8 @@
 
 ## Next PRs, in dependency order
 
-1. Admin bootstrap: an explicit command to create/promote the first admin without
-   hardcoded credentials; verify idempotence and prevent accidental password reset.
+1. Demo foundation implemented: explicit admin bootstrap and empty-catalog seeding.
+   See [demo guide](../demo.md); next build the runnable storefront.
 2. Next.js catalog: App Router, TypeScript, locked runtime, generated OpenAPI client,
    product list/detail, loading/empty/error states, and browser checks.
 3. Customer frontend auth: login/register/profile, server-mediated secure session


### PR DESCRIPTION
Stores the senior SWE portfolio plan in docs/plans/portfolio.md and links it from agent guidance. Adds explicit demo catalog and admin commands with repeat-run preservation, opt-in customer promotion, disabled-account refusal, private password prompts, and transaction rollback. Includes six fictional GBP desk accessories and a demo walkthrough. No schema or dependency changes. Validation: 77 tests and 89.7% local coverage before an additional rollback regression; all eight bootstrap tests pass. Final CI and self-review will be recorded before merge.