### PR TITLE
Align dependency minimums with the validated lockfile

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,12 +7,12 @@ dependencies = [
   "uvicorn[standard]>=0.30.6,<1",
   "sqlalchemy>=2.0.52,<2.1",
   "alembic>=1.19.2,<2",
-  "psycopg[binary]>=3.2,<4",
+  "psycopg[binary]>=3.3.5,<4",
   "pydantic[email]>=2.13.5,<3",
   "pydantic-settings>=2.7.1,<3",
   "python-multipart>=0.0.20,<1",
   "pyjwt>=2.13.0,<3",
-  "pwdlib[argon2,bcrypt]>=0.3.0,<1",
+  "pwdlib[argon2,bcrypt]>=0.3.1,<1",
   "structlog>=24.4.0,<27",
 ]
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -439,8 +439,8 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.19.2,<2" },
     { name = "fastapi", specifier = ">=0.141.1,<0.142" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
-    { name = "pwdlib", extras = ["argon2", "bcrypt"], specifier = ">=0.3.0,<1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.5,<4" },
+    { name = "pwdlib", extras = ["argon2", "bcrypt"], specifier = ">=0.3.1,<1" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.5,<3" },
     { name = "pydantic-settings", specifier = ">=2.7.1,<3" },
     { name = "pyjwt", specifier = ">=2.13.0,<3" },


### PR DESCRIPTION
Replaces Dependabot PRs #9 and #10 with the same minimum-version changes regenerated using the project toolchain. psycopg 3.3.5 and pwdlib 0.3.1 are already locked; this raises their declared floors without changing installed versions or removing unrelated wheel hashes. The runtime requirements export was regenerated and remains unchanged; the consistency check passes. Original bot CI failed because lockfile wheel-list changes left the export stale. Full tests, audit and CI will be recorded before merge.