### PR TITLE
docs: define repository naming conventions

### DIFF
--- a/.agents/skills/ecommerce-feature/SKILL.md
+++ b/.agents/skills/ecommerce-feature/SKILL.md
@@ -3,6 +3,8 @@ name: ecommerce-feature
 description: Prepare an isolated feature or fix in this ecommerce repository, accounting for worktrees, local ports, and PostgreSQL state.
 ---
 
+Use ecommerce-naming before creating a branch or naming a PR.
+
 Inspect the working tree and open PR scope. Use the current task's branch/worktree
 when already isolated; create a fresh one from the intended base if needed. Preserve
 uncommitted user work. Resolve routine non-overlapping changes without blocking.

--- a/.agents/skills/ecommerce-naming/SKILL.md
+++ b/.agents/skills/ecommerce-naming/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: ecommerce-naming
+description: Name ecommerce task branches, commits, PR titles, and squash commits using the repository's Conventional Commits policy.
+---
+
+Read the Naming conventions section of CONTRIBUTING.md before creating a branch,
+commit, or PR, and again when finalizing its title for merge. It is the canonical
+policy, including the local branch adaptation and examples.
+
+Choose names from the actual final change, not the agent identity. Never create
+an agent/ branch. Preserve existing bot branch names and real authorship when
+maintaining Dependabot PRs. Do not rewrite merged history to apply this policy.
+
+Before pushing, inspect git status, the branch name, and the commit subjects.
+Before merge, read back the PR title and explicitly pass the compliant title as
+`gh pr merge --squash --subject` so the resulting main commit follows the policy.
+Retain exact-head CI and review requirements from AGENTS.md. If scope changes,
+update the PR title to describe the final diff; branch names need not be renamed
+solely for a minor scope adjustment. Use the ownership skill for assignment/labels.

--- a/.agents/skills/ecommerce-pr-ownership/SKILL.md
+++ b/.agents/skills/ecommerce-pr-ownership/SKILL.md
@@ -3,6 +3,8 @@ name: ecommerce-pr-ownership
 description: Set and verify the owner's assignment and appropriate labels when opening or repairing pull requests in this ecommerce repository.
 ---
 
+Use ecommerce-naming for branch, commit, and PR naming before creation.
+
 The repository owner is youneshenniwrites. Before opening an agent-authored PR,
 verify `gh api user --jq .login` is that account so GitHub attributes authorship
 correctly. If a different account is authenticated, use an already-authorized

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- PR title: type(scope): description; see CONTRIBUTING.md naming conventions. -->
+
 ## Problem and resulting behavior
 
 Explain the concrete trigger and what changes for a user or maintainer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@ prerequisites. Do not claim checks passed if a missing prerequisite prevented th
 
 ## Delivery
 
-Use a task branch. Respect an existing agent-managed worktree; otherwise use a
+Use the ecommerce-naming skill for branch names, commits, PR titles, and squash
+subjects. Follow CONTRIBUTING.md: type/short-kebab-description branches, never
+agent/, and Conventional Commits subjects. Use a task branch. Respect an existing agent-managed worktree; otherwise use a
 separate worktree when concurrent changes require isolation. Inspect git status
 and overlapping PRs before editing. Allocate separate ports, Compose project names,
 and databases for concurrent runs; worktrees do not isolate running services.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,32 @@ worktrees. Never point test database overrides at customer data.
 See [tooling](docs/tooling.md) for exact checks and [development](docs/development.md)
 for database and configuration details. Coding agents should also read [AGENTS.md](AGENTS.md).
 
+## Naming conventions
+
+Follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+for commit subjects and PR titles: `type(scope): description`. Scope is optional.
+Use `feat` for features, `fix` for bugs; our other types are `docs`, `ci`, `build`,
+`test`, `refactor`, `perf`, `style`, `chore`, and `revert`. Use lowercase types and
+concise descriptions of the resulting change. Mark breaking changes with `!`
+before the colon or a `BREAKING CHANGE:` footer, and explain migration effects.
+
+The specification does not define branch names. Our local adaptation is
+`type/short-kebab-description`, with an optional area in the description:
+
+| Branch | PR title / commit subject |
+| --- | --- |
+| `feat/frontend-catalog` | `feat(frontend): add product catalog` |
+| `fix/auth-token-expiry` | `fix(auth): reject expired tokens` |
+| `docs/naming-conventions` | `docs: define repository naming conventions` |
+| `ci/checkout-update` | `ci: update checkout action` |
+
+Do not create `agent/` branches. Existing Dependabot-managed branches keep their
+bot names; apply compliant PR titles and squash subjects when merging them.
+Use the final PR title as the squash commit subject. Preserve breaking-change
+information in the squash message. This policy applies to future work; do not
+rewrite merged history. The ecommerce-naming skill guides agents through these
+checks. This is a documented review policy, not an automated CI naming gate.
+
 ## PR ownership
 
 Repository ownership is recorded in .github/CODEOWNERS. Assign maintenance PRs to

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -24,3 +24,8 @@ updates and maintenance documentation to the checks actually present in this rep
 
 The locally authored ecommerce-pr-ownership skill and REST helper assign the
 owner and add scope labels after PR creation; they preserve actual authorship.
+
+The locally authored ecommerce-naming skill applies
+[Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) to
+commit/PR subjects. Branch naming is a repository-specific adaptation, not part
+of the upstream specification. No specification text is vendored.


### PR DESCRIPTION
Adds an ecommerce-naming skill and contributor policy for Conventional Commits subjects and PR titles, plus the local type/short-kebab-description branch convention. New agent/ branches are prohibited; existing bot branches and merged history are preserved. Agent guidance and the PR template reference the policy, including explicit squash subjects. Validation: skill metadata and git diff whitespace checks pass. Documentation-only change; existing CI will run before self-review and merge.