### PR TITLE
docs(api): document the OpenAPI contract

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -13,6 +13,7 @@ from app.crud import user as crud_user
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.auth import Token
+from app.schemas.errors import ErrorResponse
 from app.schemas.user import UserCreate, UserRead
 
 router = APIRouter()
@@ -20,10 +21,18 @@ router = APIRouter()
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 
 
-@router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/register",
+    response_model=UserRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Register a customer account",
+    responses={
+        400: {"model": ErrorResponse, "description": "Email is already registered."}
+    },
+)
 def register(user_in: UserCreate, db: Session = Depends(get_db)) -> Any:
     """
-    Register a new user.
+    Create an active customer. Registration never grants admin privileges.
     """
     existing_user = crud_user.get_user_by_email(db, email=user_in.email)
     if existing_user:
@@ -42,13 +51,24 @@ def register(user_in: UserCreate, db: Session = Depends(get_db)) -> Any:
         raise
 
 
-@router.post("/login", response_model=Token)
+@router.post(
+    "/login",
+    response_model=Token,
+    summary="Sign in with email and password",
+    responses={
+        401: {
+            "model": ErrorResponse,
+            "description": "Invalid credentials or disabled account.",
+        }
+    },
+)
 def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: Session = Depends(get_db),
 ) -> Any:
     """
-    Authenticate user and return a JWT access token.
+    Submit an application/x-www-form-urlencoded body. The username field is the
+    account email. Returns a bearer JWT; use it in Authorization: Bearer <token>.
     """
     user = crud_user.get_user_by_email(db, email=form_data.username)
     valid, updated_hash = password_hash.verify_and_update(
@@ -72,7 +92,17 @@ def login(
     return {"access_token": access_token, "token_type": "bearer"}
 
 
-@router.get("/me", response_model=UserRead)
+@router.get(
+    "/me",
+    response_model=UserRead,
+    summary="Read the active user profile",
+    responses={
+        401: {
+            "model": ErrorResponse,
+            "description": "Missing, invalid or expired token, or inactive account.",
+        }
+    },
+)
 def me(current_user: User = Depends(get_current_user)) -> User:
     """
     Get the currently authenticated user.

--- a/backend/app/api/v1/products.py
+++ b/backend/app/api/v1/products.py
@@ -12,12 +12,26 @@ from app.crud.product import (
     update_product,
 )
 from app.db.session import get_db
+from app.schemas.errors import ErrorResponse
 from app.schemas.product import ProductCreate, ProductRead, ProductUpdate
 
 router = APIRouter()
+AUTH_ERRORS = {
+    401: {
+        "model": ErrorResponse,
+        "description": "Active authenticated account required.",
+    },
+    403: {"model": ErrorResponse, "description": "Admin privileges required."},
+}
+NOT_FOUND = {404: {"model": ErrorResponse, "description": "Product does not exist."}}
 
 
-@router.get("/", response_model=List[ProductRead])
+@router.get(
+    "/",
+    response_model=List[ProductRead],
+    summary="List products",
+    description="Public catalog in stable ID order. Pagination limit is 1–100; skip is 0–100000.",
+)
 def read_products(
     skip: int = Query(default=0, ge=0, le=100000),
     limit: int = Query(default=10, ge=1, le=100),
@@ -26,7 +40,12 @@ def read_products(
     return get_products(db=db, skip=skip, limit=limit)
 
 
-@router.get("/{product_id}", response_model=ProductRead)
+@router.get(
+    "/{product_id}",
+    response_model=ProductRead,
+    summary="Read a product",
+    responses=NOT_FOUND,
+)
 def read_product(product_id: int, db: Session = Depends(get_db)):
     product = get_product(db=db, product_id=product_id)
     if not product:
@@ -37,6 +56,9 @@ def read_product(product_id: int, db: Session = Depends(get_db)):
 @router.post(
     "/",
     response_model=ProductRead,
+    summary="Create a product",
+    description="Active admin only. GBP price has at most two decimal places; stock is a nonnegative integer. Unknown fields are rejected.",
+    responses=AUTH_ERRORS,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(require_admin)],
 )
@@ -45,7 +67,12 @@ def create_new_product(product_in: ProductCreate, db: Session = Depends(get_db))
 
 
 @router.put(
-    "/{product_id}", response_model=ProductRead, dependencies=[Depends(require_admin)]
+    "/{product_id}",
+    response_model=ProductRead,
+    dependencies=[Depends(require_admin)],
+    summary="Partially update a product",
+    description="Active admin only. Omitted fields retain their values; only description may explicitly be null. This PUT intentionally has partial-update semantics.",
+    responses={**AUTH_ERRORS, **NOT_FOUND},
 )
 def update_existing_product(
     product_id: int, product_in: ProductUpdate, db: Session = Depends(get_db)
@@ -59,6 +86,9 @@ def update_existing_product(
 @router.delete(
     "/{product_id}",
     status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a product",
+    description="Active admin only. Returns no body on success.",
+    responses={**AUTH_ERRORS, **NOT_FOUND},
     dependencies=[Depends(require_admin)],
 )
 def delete_existing_product(product_id: int, db: Session = Depends(get_db)):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,27 @@ logger = structlog.get_logger()
 # --------------------------
 app = FastAPI(
     title="E-Commerce API",
-    description="Backend API for E-Commerce App (FastAPI + PostgreSQL + Redis + AWS-ready)",
+    description=(
+        "Portfolio ecommerce API backed by PostgreSQL. Public catalog reads use GBP "
+        "decimal prices. Product writes require an active admin. Register a customer, "
+        "then use Authorize with your email in the username field to obtain a bearer "
+        "token. Admin bootstrap is an operator CLI, never a public endpoint. "
+        "Cart, checkout and Azure deployment are planned; no real purchases are supported."
+    ),
+    openapi_tags=[
+        {
+            "name": "Health",
+            "description": "Process liveness; does not check database readiness.",
+        },
+        {
+            "name": "Products",
+            "description": "Public catalog reads and admin-only product management. Prices serialize as two-place GBP strings.",
+        },
+        {
+            "name": "auth",
+            "description": "Customer registration, password login and active-user profile.",
+        },
+    ],
     version="0.1.0",
 )
 
@@ -42,8 +62,8 @@ app.add_middleware(
 # --------------------------
 # Health Check Endpoint
 # --------------------------
-@app.get("/health", tags=["Health"])
-async def health_check():
+@app.get("/health", tags=["Health"], summary="Check API process liveness")
+async def health_check() -> dict[str, str]:
     """
     Simple health check endpoint.
     Returns "OK" if the API is running.

--- a/backend/app/schemas/errors.py
+++ b/backend/app/schemas/errors.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    """HTTP errors use a detail string; validation errors have FastAPI's 422 schema."""
+
+    detail: str

--- a/backend/app/tests/test_openapi.py
+++ b/backend/app/tests/test_openapi.py
@@ -1,0 +1,16 @@
+def test_openapi_documents_security_errors_and_money(client):
+    schema = client.get("/openapi.json").json()
+    assert schema["openapi"].startswith("3.1.")
+    paths = schema["paths"]
+    assert "401" in paths["/api/v1/auth/me"]["get"]["responses"]
+    assert "404" in paths["/api/v1/products/{product_id}"]["get"]["responses"]
+    write = paths["/api/v1/products/"]["post"]
+    assert write["security"] == [{"OAuth2PasswordBearer": []}]
+    assert {"201", "401", "403", "422"} <= write["responses"].keys()
+    assert not paths["/api/v1/products/"]["get"].get("security")
+    assert (
+        schema["components"]["schemas"]["ProductRead"]["properties"]["price"]["type"]
+        == "string"
+    )
+    assert client.get("/docs").status_code == 200
+    assert client.get("/redoc").status_code == 200

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -1,0 +1,14 @@
+"""Export deterministic public API types without connecting to a database."""
+
+import json
+import os
+from pathlib import Path
+
+os.environ["DATABASE_URL"] = "sqlite://"
+os.environ["SECRET_KEY"] = "openapi-export-only-not-a-runtime-secret"
+
+from app.main import app  # noqa: E402
+
+if __name__ == "__main__":
+    target = Path(__file__).resolve().parents[2] / "frontend" / "openapi.json"
+    target.write_text(json.dumps(app.openapi(), indent=2, sort_keys=True) + "\n")

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,34 @@
+# API contract and interactive documentation
+
+FastAPI publishes an OpenAPI 3.1 contract for every implemented endpoint:
+
+- Swagger UI: http://localhost:8000/docs
+- ReDoc: http://localhost:8000/redoc
+- Machine-readable schema: http://localhost:8000/openapi.json
+
+Run make dev at the root first. Swagger's Authorize uses the password flow: enter
+the account email in username and its password. Public signup creates a customer;
+use the explicit admin CLI from [demo setup](demo.md) for product writes. No public
+endpoint promotes users. Do not share screenshots containing bearer tokens.
+
+The schema documents request/response models, bearer security requirements,
+pagination bounds, and 400/401/403/404 errors where applicable. FastAPI documents
+422 validation errors. Products return prices as exact two-place GBP strings;
+PUT keeps omitted fields and allows null only for description. Health is liveness,
+not database readiness. No cart, checkout or payment endpoints are claimed yet.
+
+## Contract workflow
+
+The backend owns the contract. From backend/, run:
+
+```sh
+uv run python -m scripts.export_openapi
+```
+
+The exporter uses inert local configuration and does not connect to a database.
+It writes a deterministic frontend/openapi.json snapshot. The next frontend PR
+will generate TypeScript types from this snapshot and check contract drift in CI.
+
+When changing an endpoint, update its models, summary/description, security and
+error responses, add behavior tests, then regenerate the contract. The exported
+schema includes only implemented routes; planned features belong in the roadmap.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,0 +1,921 @@
+{
+  "components": {
+    "schemas": {
+      "Body_login_api_v1_auth_login_post": {
+        "properties": {
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "format": "password",
+            "title": "Client Secret"
+          },
+          "grant_type": {
+            "anyOf": [
+              {
+                "pattern": "^password$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "password": {
+            "format": "password",
+            "title": "Password",
+            "type": "string"
+          },
+          "scope": {
+            "default": "",
+            "title": "Scope",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_login_api_v1_auth_login_post",
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "description": "HTTP errors use a detail string; validation errors have FastAPI's 422 schema.",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "ErrorResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "ProductCreate": {
+        "additionalProperties": false,
+        "properties": {
+          "currency": {
+            "const": "GBP",
+            "default": "GBP",
+            "title": "Currency",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 10000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "price": {
+            "anyOf": [
+              {
+                "maximum": 9999999999.99,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,10}|(?=[\\d.]{1,13}0*$)\\d{0,10}\\.\\d{0,2}0*$)",
+                "type": "string"
+              }
+            ],
+            "title": "Price"
+          },
+          "stock": {
+            "maximum": 2147483647.0,
+            "minimum": 0.0,
+            "title": "Stock",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "price",
+          "stock"
+        ],
+        "title": "ProductCreate",
+        "type": "object"
+      },
+      "ProductRead": {
+        "additionalProperties": false,
+        "properties": {
+          "currency": {
+            "const": "GBP",
+            "default": "GBP",
+            "title": "Currency",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 10000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "price": {
+            "title": "Price",
+            "type": "string"
+          },
+          "stock": {
+            "maximum": 2147483647.0,
+            "minimum": 0.0,
+            "title": "Stock",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "price",
+          "stock",
+          "id"
+        ],
+        "title": "ProductRead",
+        "type": "object"
+      },
+      "ProductUpdate": {
+        "additionalProperties": false,
+        "properties": {
+          "currency": {
+            "anyOf": [
+              {
+                "const": "GBP",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 10000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "price": {
+            "anyOf": [
+              {
+                "maximum": 9999999999.99,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,10}|(?=[\\d.]{1,13}0*$)\\d{0,10}\\.\\d{0,2}0*$)",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Price"
+          },
+          "stock": {
+            "anyOf": [
+              {
+                "maximum": 2147483647.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stock"
+          }
+        },
+        "title": "ProductUpdate",
+        "type": "object"
+      },
+      "Token": {
+        "properties": {
+          "access_token": {
+            "title": "Access Token",
+            "type": "string"
+          },
+          "token_type": {
+            "default": "bearer",
+            "title": "Token Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "access_token"
+        ],
+        "title": "Token",
+        "type": "object"
+      },
+      "UserCreate": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "password": {
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "UserCreate",
+        "type": "object"
+      },
+      "UserRead": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "is_superuser": {
+            "title": "Is Superuser",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "email",
+          "id",
+          "created_at",
+          "is_active",
+          "is_superuser"
+        ],
+        "title": "UserRead",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordBearer": {
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "/api/v1/auth/login"
+          }
+        },
+        "type": "oauth2"
+      }
+    }
+  },
+  "info": {
+    "description": "Portfolio ecommerce API backed by PostgreSQL. Public catalog reads use GBP decimal prices. Product writes require an active admin. Register a customer, then use Authorize with your email in the username field to obtain a bearer token. Admin bootstrap is an operator CLI, never a public endpoint. Cart, checkout and Azure deployment are planned; no real purchases are supported.",
+    "title": "E-Commerce API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1/auth/login": {
+      "post": {
+        "description": "Submit an application/x-www-form-urlencoded body. The username field is the\naccount email. Returns a bearer JWT; use it in Authorization: Bearer <token>.",
+        "operationId": "login_api_v1_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_api_v1_auth_login_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Token"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid credentials or disabled account."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Sign in with email and password",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "description": "Get the currently authenticated user.",
+        "operationId": "me_api_v1_auth_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing, invalid or expired token, or inactive account."
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Read the active user profile",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/register": {
+      "post": {
+        "description": "Create an active customer. Registration never grants admin privileges.",
+        "operationId": "register_api_v1_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Email is already registered."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Register a customer account",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/products/": {
+      "get": {
+        "description": "Public catalog in stable ID order. Pagination limit is 1\u2013100; skip is 0\u2013100000.",
+        "operationId": "read_products_api_v1_products__get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "maximum": 100000,
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProductRead"
+                  },
+                  "title": "Response Read Products Api V1 Products  Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List products",
+        "tags": [
+          "Products"
+        ]
+      },
+      "post": {
+        "description": "Active admin only. GBP price has at most two decimal places; stock is a nonnegative integer. Unknown fields are rejected.",
+        "operationId": "create_new_product_api_v1_products__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProductCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Active authenticated account required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Admin privileges required."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create a product",
+        "tags": [
+          "Products"
+        ]
+      }
+    },
+    "/api/v1/products/{product_id}": {
+      "delete": {
+        "description": "Active admin only. Returns no body on success.",
+        "operationId": "delete_existing_product_api_v1_products__product_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "title": "Product Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Active authenticated account required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Admin privileges required."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Product does not exist."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete a product",
+        "tags": [
+          "Products"
+        ]
+      },
+      "get": {
+        "operationId": "read_product_api_v1_products__product_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "title": "Product Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Product does not exist."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read a product",
+        "tags": [
+          "Products"
+        ]
+      },
+      "put": {
+        "description": "Active admin only. Omitted fields retain their values; only description may explicitly be null. This PUT intentionally has partial-update semantics.",
+        "operationId": "update_existing_product_api_v1_products__product_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "title": "Product Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProductUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Active authenticated account required."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Admin privileges required."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Product does not exist."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Partially update a product",
+        "tags": [
+          "Products"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Simple health check endpoint.\nReturns \"OK\" if the API is running.",
+        "operationId": "health_check_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Health Check Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Check API process liveness",
+        "tags": [
+          "Health"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Process liveness; does not check database readiness.",
+      "name": "Health"
+    },
+    {
+      "description": "Public catalog reads and admin-only product management. Prices serialize as two-place GBP strings.",
+      "name": "Products"
+    },
+    {
+      "description": "Customer registration, password login and active-user profile.",
+      "name": "auth"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Documents the implemented FastAPI contract in Swagger UI, ReDoc, and OpenAPI 3.1. Adds authentication guidance, error schemas, GBP price semantics, pagination limits, and partial-update behavior. Removes the obsolete AWS-ready description.

## Jira ticket

No Jira ticket.

## Changes

- Add a deterministic schema exporter and versioned OpenAPI snapshot.
- Document public catalog access and active-admin write permissions.
- Verify documentation availability, security declarations, and response schemas.

## Validation

- Local backend suite: **79 tests passed**.
- Ruff lint and formatting: **passed**.
- Backend, PostgreSQL, container, and dependency-audit CI: **passed**.
- Exact revision and self-review are recorded in the review before merge.

## Compatibility and operations

No database migration or commerce behavior changes. Frontend type generation and CI drift checks follow in PR #17.
