### PR TITLE
ci: clarify full-stack verification stages

### DIFF
--- a/.agents/skills/ecommerce-pr-ownership/SKILL.md
+++ b/.agents/skills/ecommerce-pr-ownership/SKILL.md
@@ -11,6 +11,10 @@ correctly. If a different account is authenticated, use an already-authorized
 owner connection or report the mismatch; never falsify authorship or rewrite history.
 Existing bot/contributor PRs retain their real authors.
 
+Use the PR template for a readable description: summary, Jira ticket, validation,
+and compatibility/operations. Include the real Jira key/link if provided; otherwise
+write "No Jira ticket." Never invent an issue or imply one is attached.
+
 After creating a PR, choose labels that describe its actual scope: bug,
 enhancement, documentation, tooling, dependencies, github_actions, or docker.
 Apply assignment and labels from the repository root:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 2
+  - package-ecosystem: npm
+    directory: /frontend
+    assignees: [youneshenniwrites]
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    groups:
+      frontend-patches:
+        update-types: ["patch"]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,11 @@
 
 Explain the concrete trigger and what changes for a user or maintainer.
 
+## Jira ticket
+
+No Jira ticket.
+<!-- Replace with the real ticket key and link when one exists; never invent a ticket. -->
+
 ## Validation
 
 List the commands/results and the exact revision tested. Mark unavailable checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,30 @@ concurrency:
   cancel-in-progress: true
 jobs:
   backend:
+    name: Backend · Lint, contract and unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python dependency tooling
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           version: "0.8.22"
           enable-cache: true
-      - run: uv sync --locked --python 3.12
-      - run: uv run ruff check .
-      - run: uv run ruff format --check .
-      - run: uv run python scripts/check_requirements.py
-      - run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml
+      - name: Install locked backend dependencies
+        run: uv sync --locked --python 3.12
+      - name: Run Ruff lint
+        run: uv run ruff check .
+      - name: Check Python formatting
+        run: uv run ruff format --check .
+      - name: Verify lockfile and requirements consistency
+        run: uv run python scripts/check_requirements.py
+      - name: Run backend tests and enforce coverage
+        run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -34,14 +42,20 @@ jobs:
           path: backend/coverage.xml
           retention-days: 14
   container:
+    name: Backend · Container build and migration smoke tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: python3 backend/scripts/dev_setup.py
-      - run: docker compose --env-file backend/.env up --build --wait --wait-timeout 180
-      - run: python3 backend/scripts/smoke.py
-      - run: docker compose --env-file backend/.env exec -T api alembic check
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Generate disposable CI configuration
+        run: python3 backend/scripts/dev_setup.py
+      - name: Build containers, apply migrations and wait for health
+        run: docker compose --env-file backend/.env up --build --wait --wait-timeout 180
+      - name: Test API authentication and authorization
+        run: python3 backend/scripts/smoke.py
+      - name: Verify database schema matches migrations
+        run: docker compose --env-file backend/.env exec -T api alembic check
       - name: Check migration rollback on disposable database
         run: |
           docker compose --env-file backend/.env stop api
@@ -55,6 +69,7 @@ jobs:
         if: always()
         run: docker compose --env-file backend/.env down --volumes
   postgres:
+    name: Backend · PostgreSQL integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
@@ -73,12 +88,15 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python dependency tooling
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           version: "0.8.22"
           enable-cache: true
-      - run: uv sync --locked --python 3.12
+      - name: Install locked backend dependencies
+        run: uv sync --locked --python 3.12
       - name: Create separate disposable migration database
         run: |
           uv run python - <<'PY'
@@ -86,7 +104,8 @@ jobs:
           with psycopg.connect("postgresql://ecommerce:ci-only-password@localhost:5432/ecommerce_test", autocommit=True) as connection:
               connection.execute("CREATE DATABASE ecommerce_migrations")
           PY
-      - run: uv run pytest -q
+      - name: Run full test suite against PostgreSQL
+        run: uv run pytest -q
         env:
           TEST_DATABASE_URL: postgresql+psycopg://ecommerce:ci-only-password@localhost:5432/ecommerce_test
           TEST_MIGRATION_DATABASE_URL: postgresql+psycopg://ecommerce:ci-only-password@localhost:5432/ecommerce_migrations

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -10,23 +10,51 @@ permissions:
   contents: read
 jobs:
   dependency-audit:
+    name: Backend · Dependency audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python dependency tooling
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           version: "0.8.22"
           enable-cache: true
-      - run: uv sync --locked --python 3.12
-      - run: uv run pip-audit --strict --format json --output dependency-audit.json
+      - name: Install locked backend dependencies
+        run: uv sync --locked --python 3.12
+      - name: Audit Python dependencies
+        run: uv run pip-audit --strict --format json --output dependency-audit.json
       - name: Upload audit report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dependency-audit
           path: backend/dependency-audit.json
+          retention-days: 14
+  frontend-audit:
+    name: Frontend · Scheduled dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up pinned Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: frontend/.nvmrc
+      - name: Set up pinned npm
+        run: npm install --global npm@11.19.1
+      - name: Audit locked frontend dependencies
+        working-directory: frontend
+        run: npm audit --json > audit.json
+      - name: Upload audit results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: frontend-dependency-audit
+          path: frontend/audit.json
           retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,9 @@ is the actual GitHub account that opens the PR; do not forge a different author.
 
 ## Review and merge
 
+Use the PR template headings. Include a Jira ticket section with the actual key
+and link, or write "No Jira ticket." Never invent a ticket reference.
+
 Explain the problem and resulting behavior, then give the commands/results and
 material limitations. Include relevant screenshots for UI changes, or API/test
 output for backend changes. Do not include tokens, passwords, or customer data.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Backend CI runs three jobs, with dependency auditing in a separate workflow:
 Frontend CI also checks formatting, lint, types, API contract drift, unit coverage,
 a production build, and desktop/mobile browser and accessibility behavior. It
 archives browser evidence and the validated standalone build.
-See [frontend verification](frontend/README.md) for commands and evidence.
+See [CI and deployment status](docs/ci.md) for the full pipeline.
 
 Coverage and audit artifacts remain available for 14 days. Dependabot proposes
 weekly Python, CI action, and Docker updates; updates still need review and checks.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,38 @@
+# CI and delivery pipeline
+
+Every PR and main push runs backend and frontend verification. Job and step names
+state the operation being performed, so a failed build, test or audit is identifiable
+without reading shell commands. Workflows have read-only repository permissions,
+pinned action SHAs, timeouts and cancellation of superseded runs.
+
+| Workflow / job | Ordered work | Evidence |
+| --- | --- | --- |
+| Backend / Lint, contract and unit tests | Locked install → lint → format → export consistency → tests/coverage | Backend coverage XML |
+| Backend / PostgreSQL integration tests | Start disposable PostgreSQL → create separate migration DB → full tests | Test logs |
+| Backend / Container build and migration smoke tests | Image build → migrations/startup → HTTP smoke → schema consistency → rollback/reapply | Failure logs |
+| Frontend / Lint, types, contract and unit tests | npm ci → regenerate/check API contract → formatting → lint → types → unit coverage → audit | LCOV coverage |
+| Frontend / Production build and browser tests | Production build → disposable real API → desktop/mobile/axe and fault tests → package | Browser report, traces, screenshots, standalone build |
+| Dependency audit / Python and frontend | Audit locked dependencies on PR/push, weekly, or manually | JSON reports |
+
+The frontend browser job depends on its quality job. Backend jobs run independently
+so failures do not hide other evidence. Unit coverage measures catalog/money logic;
+route rendering, API integration and failure screens are covered by browser tests.
+FastAPI's generated OpenAPI snapshot is checked in CI so API drift fails the PR.
+
+## Build versus deployment
+
+A successful build is not a deployment. The frontend workflow produces a standalone
+build artifact only after browser tests pass. The workflow summary explicitly marks
+Azure deployment as not configured; there is no fake deploy job or cloud operation.
+
+Azure staging will add: approved budget/environment → workload identity → image
+publication → migration execution → deployment → health/smoke verification, with
+rollback and logs. Provisioning remains a separate portfolio milestone.
+
+## Reading a failure
+
+Open the failing named check, expand its failed step, then use its associated
+artifact. Fix the root cause and rerun checks for the new head; do not skip tests
+or suppress an audit to merge. Reports expire after 14 days. Fork PRs receive no
+cloud secrets. Branch-protection required-check settings remain a separate admin
+control; workflow definitions alone do not enforce repository rules.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,7 +1,8 @@
 # Engineering checks
 
-The repository has four CI jobs: backend lint/format/tests with coverage, full
-PostgreSQL tests, container startup/migration checks, and dependency auditing.
+The repository checks both applications. See [CI pipeline](ci.md) for frontend
+quality, build/browser checks and the named backend stages. Backend checks cover
+lint/format/tests, PostgreSQL, containers/migrations and dependency auditing.
 These checks support review; they do not certify production readiness.
 
 | Command | Purpose |
@@ -31,7 +32,7 @@ Dependabot checks Python/uv, GitHub Actions, and backend Docker dependencies wee
 Python patch updates are grouped; open PR counts are limited. Changes still need
 review and CI. An agent handling a uv update must regenerate requirements.txt if
 Dependabot leaves it stale; the requirements check deliberately prevents drift.
-Frontend dependency updates will be added when a frontend package manifest exists.
+Frontend npm dependency updates are enabled weekly, with at most two open PRs.
 
 CI actions are pinned to reviewed commit SHAs, with version comments for readers.
 Dependabot can propose updated pins. Jobs have time limits and read-only repository

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -61,4 +61,4 @@ npm run build assembles .next/standalone with static assets. Run npm start with
 PORT and HOSTNAME environment variables to serve that package. CI archives the
 contents; after extraction use node server.js with API_BASE_URL configured.
 
-Azure deployment is not configured. See .github/workflows/frontend.yml at the repository root for the delivery pipeline.
+Azure deployment is not configured. See ../docs/ci.md for the delivery pipeline.


### PR DESCRIPTION
## Summary

Makes full-stack CI readable by naming backend jobs and steps after their actual work. Extends scheduled dependency auditing to the frontend and documents build evidence separately from deployment.

## Jira ticket

No Jira ticket.

## Changes

- Name backend installation, lint, formatting, test, container, and migration stages.
- Add frontend audit reports and weekly npm dependency-update proposals.
- Document pipeline ordering, retained artifacts, and failure investigation.
- Standardize PR descriptions and require a real Jira reference or explicit "No Jira ticket."

## Validation

- Workflow YAML parsing: **passed locally**.
- Existing backend and frontend checks were exercised while preparing the stack.
- Final GitHub CI results and the exact reviewed revision are recorded before merge.

## Compatibility and operations

Retains read-only workflow permissions and pinned actions. Azure deployment is explicitly **not configured**; these workflows provision no cloud resources. Repository branch-protection rules remain a separate control.

## Dependencies

PR #17 is merged. This PR now targets `main`; all checks rerun on the final head.
