### PR TITLE
docs(api): clarify local startup and Postman onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,18 @@ installs the locked Python environment, builds the API image, starts PostgreSQL,
 applies migrations, and waits for the API health check. Credentials are local-only
 and excluded from Git and the Docker build context.
 
+**These links open services on your own computer, not a hosted GitHub demo.**
+Wait for `make dev` to succeed before opening them. If Docker or the API is stopped,
+the links will be unavailable.
+
 - API documentation: [localhost:8000/docs](http://localhost:8000/docs)
 - ReDoc: [localhost:8000/redoc](http://localhost:8000/redoc)
 - OpenAPI contract: [localhost:8000/openapi.json](http://localhost:8000/openapi.json)
 - Health: [localhost:8000/health](http://localhost:8000/health)
+
+For a first API request, authentication, and Postman import, follow the
+[API onboarding guide](docs/api.md). The [checked-in OpenAPI contract](frontend/openapi.json)
+can be downloaded even while the API is offline; executing requests requires the stack.
 
 For the storefront, run `make demo`, then `cd frontend && npm ci && npm run dev`
 with Node 24.20.0 and npm 11.19.1. Open [localhost:3000](http://localhost:3000).

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,10 +6,88 @@ FastAPI publishes an OpenAPI 3.1 contract for every implemented endpoint:
 - ReDoc: http://localhost:8000/redoc
 - Machine-readable schema: http://localhost:8000/openapi.json
 
-Run make dev at the root first. Swagger's Authorize uses the password flow: enter
-the account email in username and its password. Public signup creates a customer;
-use the explicit admin CLI from [demo setup](demo.md) for product writes. No public
-endpoint promotes users. Do not share screenshots containing bearer tokens.
+## Start and verify the local API
+
+These URLs refer to **your computer**. GitHub displays the source and contract;
+it does not run the API. There is no hosted Azure API yet.
+
+Start Docker Desktop (or your Docker engine), then from the repository root:
+
+```sh
+make dev
+make demo
+curl --fail http://localhost:8000/health
+curl --fail 'http://localhost:8000/api/v1/products/?skip=0&limit=10'
+```
+
+Expect `{"status":"ok"}` and a JSON product list. Demo seeding only populates an
+empty catalog. The catalog request also checks database access; health alone is
+process liveness. `make down` stops the services and preserves the database.
+
+## Explore with Swagger
+
+Open [Swagger UI](http://localhost:8000/docs). Expand a product GET operation,
+choose **Try it out**, then **Execute** to inspect its URL, status and JSON body.
+To explore customer authentication:
+
+1. Execute `POST /api/v1/auth/register` with a unique demo email and a password
+   of 8–128 characters. Use fictional data and a password you do not reuse.
+2. Click **Authorize**. Enter that email in `username` and the password in
+   `password`; leave client credentials empty. Swagger obtains a bearer token.
+3. Execute `GET /api/v1/auth/me` to inspect the authenticated profile.
+
+Public signup creates a customer. Product writes require an active admin created
+through the explicit CLI in [demo setup](demo.md); no public endpoint promotes
+users. Do not share screenshots or exports containing passwords or bearer tokens.
+
+## Import into Postman
+
+Postman supports this OpenAPI 3.1 contract; see its
+[official import guide](https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/).
+
+1. With the API running, select **Import** in Postman and enter
+   `http://localhost:8000/openapi.json`. Alternatively, download the repository's
+   [OpenAPI snapshot](../frontend/openapi.json) and import that file. It contains
+   the same contract checked by CI and is available without a running API.
+2. Generate a collection from the specification. Set its base URL variable to
+   `http://localhost:8000` (the importer may call it `baseUrl`). Check that the
+   resolved request URL begins with this address before sending.
+3. Send the health and product-list requests first. Then register a fictional
+   customer using the JSON request schema.
+4. Send `POST /api/v1/auth/login` with **Body → x-www-form-urlencoded**:
+   `username` is the registered email and `password` is its password. This
+   endpoint accepts form fields, not a JSON login body.
+5. Copy `access_token` from the response into a local, unshared Postman variable
+   named `accessToken`. On the profile request, select **Authorization → Bearer
+   Token** and use `{{accessToken}}`. Send `GET /api/v1/auth/me`; expect HTTP 200.
+
+Use the Postman desktop application or its Desktop Agent for localhost requests;
+a cloud agent cannot reach a server on your laptop. Keep token/password values
+local and out of Git or shared collection exports. An expired token requires login
+again. Swagger is an equivalent interactive client and needs no Postman account.
+
+## Troubleshooting
+
+| Symptom | Check / recovery |
+| --- | --- |
+| Connection refused / browser cannot connect | Start Docker, run `make dev`, and wait for success. |
+| Docker daemon unavailable | Open Docker Desktop and wait for its engine to start; retry `make dev`. |
+| Port already allocated | Check which local process owns port 8000 or 5432; do not stop unrelated services blindly. Compose supports `API_PORT` / `DB_PORT` overrides; update client URLs and the host database configuration accordingly. |
+| API starts but catalog fails | Inspect service status and logs below; health does not verify the database. |
+| Login returns 422 | Use form-encoded `username` and `password`, not JSON. |
+| Profile returns 401 | Log in again and send the returned bearer token. |
+| Product write returns 403 | A customer token cannot perform admin operations. |
+
+From the repository root:
+
+```sh
+docker compose --env-file backend/.env ps
+docker compose --env-file backend/.env logs --tail=80 api migrate db
+```
+
+Do not delete database volumes to fix a startup error. Redact credentials and
+personal data before sharing logs. Restart the stack after restarting your machine
+if the services are no longer running.
 
 The schema documents request/response models, bearer security requirements,
 pagination bounds, and 400/401/403/404 errors where applicable. FastAPI documents


### PR DESCRIPTION
## Summary
Clarify that README API links require a running local stack, and provide a complete onboarding walkthrough from startup to authenticated requests.

## Jira ticket
No Jira ticket.

## Changes
- Explain local URLs and provide an offline OpenAPI snapshot link.
- Document Swagger exploration and Postman OpenAPI import, form login, bearer authentication, and admin boundaries.
- Add startup, port, database, and authentication troubleshooting.

## Validation
- Reviewed commands against Compose, Makefile, routes, and request schemas.
- Verified Postman OpenAPI 3.1 support against official documentation.
- `git diff --check` passed.
- Live Docker/PostgreSQL stack passed: docs, ReDoc, OpenAPI, health and catalog HTTP 200; six demo products. Fictional customer registration 201, form login 200, bearer profile 200, unauthenticated profile 401.
- All seven backend/frontend CI checks passed on d387ac1.
- Self-review: full two-file diff checked against implemented routes and startup commands; no blocking findings.

## Compatibility and operations
Documentation only; no API, schema, dependency, or deployment changes. Azure hosting remains planned. Credentials and tokens must remain local.
