### PR TITLE
ci: gate merges on verified Codex review evidence

### DIFF
--- a/.agents/skills/ecommerce-pr-ownership/SKILL.md
+++ b/.agents/skills/ecommerce-pr-ownership/SKILL.md
@@ -49,6 +49,10 @@ activity before posting to avoid duplicate requests; request a new review when
 code changes invalidate the reviewed head. Verify the actual bot response and
 reviewed commit. Do not assume the integration bot is a requestable GitHub user.
 
-External review and approval are required before merge. Self-review and CI alone
-are insufficient. Comments/reactions are not automatically formal approvals;
-leave the PR open if the required signal is missing. Never bypass protection.
+External review and approval are required before merge. Follow docs/codex-review.md:
+post a fresh commit-bound request, verify the trusted bot's clean result for the
+current head and all resolved threads, and require the Codex review status plus
+CI. Verify ticket acceptance separately. No human Approve review is required.
+Self-review and CI alone are insufficient. Missing evidence keeps the PR open.
+Never bypass protection. After pushing, publish a pending Codex review status if
+the workflow has not yet run; never publish success without the evidence adapter.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ Closes #<!-- actual issue number; use Refs #N for partial work -->
 - [ ] Review findings addressed
 - [ ] Required CI checks passed
 - [ ] Required external approval verified for the latest commit
-<!-- Keep the owner as assignee; request only Codex as reviewer. Trigger Codex review through its integration; naming it here does not request a review. A comment or reaction is not automatically a formal approval. -->
+<!-- Keep the owner as assignee; request only Codex as reviewer. Trigger Codex review through its integration; naming it here does not request a review. The Codex review status must validate the current-head clean-review evidence described in docs/codex-review.md; a human Approve review is not required. -->
 
 ## Deployment / Compatibility
 <!-- Optional: omit if not applicable. -->

--- a/.github/workflows/codex-review-events.yml
+++ b/.github/workflows/codex-review-events.yml
@@ -1,0 +1,15 @@
+name: Codex review events
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+permissions: {}
+jobs:
+  notify:
+    name: Notify trusted review gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      # No checkout, secrets, write token or PR content. The default-branch
+      # workflow_run receiver independently fetches all evidence from GitHub.
+      - name: Signal that review evidence changed
+        run: echo 'Review event received; trusted gate will refresh its evidence.'

--- a/.github/workflows/codex-review-events.yml
+++ b/.github/workflows/codex-review-events.yml
@@ -2,6 +2,8 @@ name: Codex review events
 on:
   pull_request_review:
     types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
 permissions: {}
 jobs:
   notify:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,34 @@
+name: Codex review gate
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  issue_comment:
+    types: [created, edited, deleted]
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  statuses: write
+concurrency:
+  group: codex-review-evidence
+  cancel-in-progress: false
+jobs:
+  evaluate:
+    name: Refresh Codex review progress
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Never check out or execute pull-request code with the write token.
+      - name: Check out trusted default-branch gate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - name: Verify Codex identity, current commit, clean result and resolved threads
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEW_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/codex_review_gate.py --repo "$REVIEW_REPOSITORY" --publish

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -4,6 +4,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   issue_comment:
     types: [created, edited, deleted]
+  workflow_run:
+    workflows: [Codex review events]
+    types: [requested, completed]
   schedule:
     - cron: '*/5 * * * *'
   workflow_dispatch:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,7 +1,7 @@
 name: Codex review gate
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, edited, closed]
   issue_comment:
     types: [created, edited, deleted]
   workflow_run:

--- a/.github/workflows/review-gate-tests.yml
+++ b/.github/workflows/review-gate-tests.yml
@@ -1,0 +1,18 @@
+name: Review gate tests
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  tests:
+    name: Review gate · Evidence validation tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Test stale, spoofed, running and unresolved review rejection
+        run: python3 -m unittest discover -s scripts/tests -v

--- a/.github/workflows/review-gate-tests.yml
+++ b/.github/workflows/review-gate-tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 jobs:
   tests:
     name: Review gate · Evidence validation tests
@@ -16,3 +18,10 @@ jobs:
           persist-credentials: false
       - name: Test stale, spoofed, running and unresolved review rejection
         run: python3 -m unittest discover -s scripts/tests -v
+      - name: Inspect live Codex evidence (read only; does not approve)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEW_REPOSITORY: ${{ github.repository }}
+          REVIEW_PR: ${{ github.event.pull_request.number }}
+        run: python3 scripts/codex_review_gate.py --repo "$REVIEW_REPOSITORY" --pr "$REVIEW_PR"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ backend/.env
 
 frontend/storefront-build.tar.gz
 frontend/audit.json
+
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,13 @@ proposed design, not implemented behavior.
 
 ## External review requirement
 
-The owner requires external tool review and approval before any PR merge.
-Self-review and passing CI are necessary but insufficient. Verify that approval
-covers the current head and resolve findings; request review again after changes.
-Never use an admin bypass or weaken protection to merge. A comment, reaction, or
-absence of findings is not automatically a formal approving GitHub review. If the
-selected tool cannot supply the required signal, leave the PR open and report it.
+The owner accepts a completed clean Codex review of the latest commit, with all
+findings addressed and threads resolved, as external approval. Follow
+[the review gate protocol](docs/codex-review.md); require the `Codex review` status
+and all applicable CI, and independently verify ticket acceptance criteria.
+Self-review is disclosed and cannot replace external review. Request a new review
+after changes. No human reviewer is required. Never bypass protection or invent a
+clean result. Missing, stale or unrecognized evidence keeps the PR open.
 
 The canonical PR format is .github/pull_request_template.md. Use the
 ecommerce-pr-ownership skill to fill it, assign the owner, and request/verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,9 @@ output for backend changes. Do not include tokens, passwords, or customer data.
 
 Review the exact pushed revision. Address actionable findings and rerun affected
 checks. A self-review must say it is a self-review; it is not independent approval.
-All applicable CI jobs must pass before merge. No workflow in this repository
+All applicable CI jobs and the [Codex review gate](docs/codex-review.md) must pass
+before merge. A verified clean external review replaces a human approval; ticket
+acceptance must still be checked. No workflow in this repository
 bypasses review to automatically merge dependency updates.
 
 Merge permission does not authorize Azure provisioning. Cloud deployments need

--- a/docs/ci-self-review.md
+++ b/docs/ci-self-review.md
@@ -1,0 +1,47 @@
+# CI self-review — 8 September 2026
+
+Implementation self-review for #37, covering all six workflow files, the review
+adapter, publication code, regression tests and the main-protection configuration.
+This does not replace external Codex review.
+
+## Findings fixed in the consolidated revision
+
+| Finding | Reproduction and correction |
+| --- | --- |
+| An evidence API failure abandoned later PRs, leaving their old status untouched | A regression failed against the previous publisher. Processing now isolates errors per PR and continues through all commit groups; the overall run fails if any refresh fails. |
+| Two PRs sharing a SHA could overwrite a pending result with success | A regression reproduced the incorrect final success. Publication now aggregates every open PR sharing the SHA, including scoped refreshes. |
+| Every poll consumed new commit statuses, eventually hitting GitHub's limit | The publisher now compares the last state and reason. A test runs 1,001 identical refreshes and requires one status write. |
+
+Additional checks cover head/draft changes during inspection, REST and GraphQL
+pagination, partial responses, repeated cursors, status-write failures, untrusted
+review requests, stale/forged results and dismissed findings. Existing Codex
+findings on commenter authorization, review events and dismissal remain covered.
+The final external finding on edited older reviews is covered using GraphQL
+updatedAt and inline comment timestamps. All 42 regression tests pass locally.
+
+## Workflow inspection
+
+- Write-enabled review refresh checks out only default-branch code, persists no
+  credentials, and consumes no relay artifacts, PR dependencies or shell content.
+- The review-event relay has no token permissions or checkout. Its receiver uses
+  default-branch workflow_run events and fetches evidence independently.
+- Backend/frontend/audit/test workflows use read permissions and pinned actions.
+  Test databases and Compose teardown are confined to disposable hosted runners.
+- All six YAML files parse; all action references are full commit SHAs, and every
+  job has a timeout. Runtime checks continue in GitHub CI.
+- Head pushes, reopening, draft transitions, base edits and closure refresh the
+  gate. Review events use the relay; reactions/thread resolution also have polling.
+- Main's current CI/admin/conversation requirements were inspected. Human approval
+  replacement and first default-branch activation still require final verification.
+
+## Explicit limits
+
+An Actions inspection result is a snapshot, not Codex's internal execution log.
+GitHub scheduling and API outages can delay it. If listing PRs or writing statuses
+fails, code cannot guarantee that GitHub has removed an old green status; merging
+requires a fresh successful refresh and current evidence. Protection coverage and
+merge-button behaviour on other targets remain deferred in #38. No deployment or
+claim of production readiness is included.
+
+Sources: [GitHub status semantics and limits](https://docs.github.com/en/rest/commits/statuses),
+[workflow event trust and lifecycle](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run).

--- a/docs/codex-review.md
+++ b/docs/codex-review.md
@@ -8,7 +8,9 @@ shipping agent; this gate does not infer task completion from resolved comments.
 
 ## Request and evidence
 
-Request review using a new, unedited comment (substitute the full current SHA):
+Request review as a repository owner, member or collaborator, using a new,
+unedited comment containing exactly the request below (substitute the full current
+SHA). Incidental mentions and outsider comments are not authoritative requests:
 
 ```
 @codex review

--- a/docs/codex-review.md
+++ b/docs/codex-review.md
@@ -26,7 +26,10 @@ missing evidence leaves the check pending. Re-request review after changes.
 
 The required commit status is **Codex review**. It shows a pending indicator and
 short reason while reviewing; success means the evidence conditions passed. It is
-not a percentage progress bar. The separate workflow refreshes evidence on PR and
+not a percentage progress bar. Its Details link opens the Actions run that
+inspected the evidence, with logs and a readable summary. PR test runs also
+inspect live evidence with a read-only token; their green job result means the
+inspection ran, not that Codex approved. The separate workflow refreshes evidence on PR and
 comment events, manually, and approximately every five minutes to catch
 reactions and resolved threads (GitHub scheduling may be delayed).
 
@@ -44,7 +47,8 @@ Protect main with this required status plus normal CI, up-to-date branches and
 resolved conversations. Do not remove an existing approval requirement until the
 replacement has been tested and its current-head success verified. Bootstrap may
 run the reviewed gate locally with gh credentials to publish a real evidence-backed
-status; it must not fabricate a pass. After installation, use workflow_dispatch
+status; it must not fabricate a pass. Local publication requires `--details-url`
+pointing to the real evidence Actions run, never a PR URL. After installation, use workflow_dispatch
 for recovery, and inspect the workflow failure before retrying. Missing clean bot
 signals require investigation, never an assumed approval.
 

--- a/docs/codex-review.md
+++ b/docs/codex-review.md
@@ -32,13 +32,15 @@ not a percentage progress bar. Its Details link opens the Actions run that
 inspected the evidence, with logs and a readable summary. PR test runs also
 inspect live evidence with a read-only token; their green job result means the
 inspection ran, not that Codex approved. The separate workflow refreshes evidence on PR and
-comment events, manually, and approximately every five minutes to catch
+comment events, a read-only review-event relay, manually, and approximately every five minutes to catch
 reactions and resolved threads (GitHub scheduling may be delayed).
 
 ## Trust and operations
 
 The write-enabled workflow uses pull_request_target, default-branch issue_comment,
-schedule and manual events. It executes only the protected default branch's gate code,
+schedule, manual and default-branch workflow_run events. Review submissions,
+edits and dismissals trigger a separate permissionless relay; the receiver reads
+fresh GitHub evidence and never trusts relay artifacts or executes its code. It executes only the protected default branch's gate code,
 never pull-request code. It does not install PR dependencies or interpolate PR
 content into shell commands. Evidence is paginated; API failures abort evaluation
 with a pending status. New SHAs require their own success. The protocol adapter is

--- a/docs/codex-review.md
+++ b/docs/codex-review.md
@@ -1,0 +1,52 @@
+# Automated Codex review gate
+
+The owner's accepted approval signal is a completed clean Codex review of the
+latest commit with every review thread resolved. A human Approve review is not
+required once this gate is installed and required in branch protection. CI remains
+mandatory. Ticket acceptance still requires implementation evidence checked by the
+shipping agent; this gate does not infer task completion from resolved comments.
+
+## Request and evidence
+
+Request review using a new, unedited comment (substitute the full current SHA):
+
+```
+@codex review
+<!-- codex-review-head:FULL_40_CHARACTER_HEAD_SHA -->
+```
+
+The gate requires this commit-bound request, a fresh completed Code Review summary
+from the verified Codex bot (GitHub user ID 199175422), the matching summary commit,
+a +1 reaction from that bot on the request (or its explicit, unedited clean-result
+comment identifying the current commit), and no unresolved review threads. The
+explicit-result path also supports existing unedited review requests. Later
+requests or findings invalidate an older clean result.
+An old clean review, edited request, human reaction, unknown summary format or
+missing evidence leaves the check pending. Re-request review after changes.
+
+The required commit status is **Codex review**. It shows a pending indicator and
+short reason while reviewing; success means the evidence conditions passed. It is
+not a percentage progress bar. The separate workflow refreshes evidence on PR and
+comment events, manually, and approximately every five minutes to catch
+reactions and resolved threads (GitHub scheduling may be delayed).
+
+## Trust and operations
+
+The write-enabled workflow uses pull_request_target, default-branch issue_comment,
+schedule and manual events. It executes only the protected default branch's gate code,
+never pull-request code. It does not install PR dependencies or interpolate PR
+content into shell commands. Evidence is paginated; API failures abort evaluation
+with a pending status. New SHAs require their own success. The protocol adapter is
+fail-closed because Codex's summary format can change. Unit tests cover spoofed,
+stale, edited and incomplete evidence. Separate read-only CI tests PR changes.
+
+Protect main with this required status plus normal CI, up-to-date branches and
+resolved conversations. Do not remove an existing approval requirement until the
+replacement has been tested and its current-head success verified. Bootstrap may
+run the reviewed gate locally with gh credentials to publish a real evidence-backed
+status; it must not fabricate a pass. After installation, use workflow_dispatch
+for recovery, and inspect the workflow failure before retrying. Missing clean bot
+signals require investigation, never an assumed approval.
+
+The gate does not merge PRs itself. The shipping agent verifies ticket acceptance,
+all required checks and current-head evidence before merging. No admin bypass.

--- a/docs/codex-review.md
+++ b/docs/codex-review.md
@@ -22,7 +22,9 @@ from the verified Codex bot (GitHub user ID 199175422), the matching summary com
 a +1 reaction from that bot on the request (or its explicit, unedited clean-result
 comment identifying the current commit), and no unresolved review threads. The
 explicit-result path also supports existing unedited review requests. Later
-requests or findings invalidate an older clean result.
+requests or findings invalidate an older clean result. Review edits use GraphQL
+update timestamps; inline comments are checked separately, including resolved
+threads whose comments were later edited.
 An old clean review, edited request, human reaction, unknown summary format or
 missing evidence leaves the check pending. Re-request review after changes.
 
@@ -42,8 +44,20 @@ schedule, manual and default-branch workflow_run events. Review submissions,
 edits and dismissals trigger a separate permissionless relay; the receiver reads
 fresh GitHub evidence and never trusts relay artifacts or executes its code. It executes only the protected default branch's gate code,
 never pull-request code. It does not install PR dependencies or interpolate PR
-content into shell commands. Evidence is paginated; API failures abort evaluation
-with a pending status. New SHAs require their own success. The protocol adapter is
+content into shell commands. Evidence is paginated with bounded cursors. A failure
+in one PR does not abandon the others: affected commit groups stay pending and
+the workflow fails. PRs sharing a SHA are evaluated together; all must pass,
+including when using a scoped refresh. Head and draft state are checked again
+after inspection. New SHAs require their own success.
+
+Publication occurs only when state or reason changes, avoiding GitHub's limit of
+1,000 statuses per SHA/context. The Details link therefore identifies the last
+status transition; unchanged refreshes are available in Actions. If GitHub cannot
+list PRs or accept a status write, the workflow fails but cannot erase an old
+status remotely. The shipping agent must require a successful fresh refresh and
+recheck current-head evidence before merging. Events and API reads are snapshots,
+not an atomic lock against a concurrent review. Broader UI/protection enforcement
+is tracked separately in #38. The protocol adapter is
 fail-closed because Codex's summary format can change. Unit tests cover spoofed,
 stale, edited and incomplete evidence. Separate read-only CI tests PR changes.
 

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -37,8 +37,9 @@ assign youneshenniwrites and apply scope labels. Self-review must be identified.
 Before merge, review the full exact-head diff, resolve findings and require all
 applicable checks and external tool review/approval for the current head.
 Self-review alone does not authorize merging. Never bypass branch protection.
-If the tool provides only comments or reactions, do not assume these satisfy a
-required approving review; leave the PR open until the integration is resolved.
+The required `Codex review` status validates the owner-approved clean-review
+signal; follow [its evidence protocol](codex-review.md). A human Approve review is
+not required. Unknown or missing evidence must keep the PR open.
 After merge, verify issue closure, update board status, record
 evidence and identify the next unblocked Backlog ticket. Check README, design notes,
 roadmap, Wiki and skills for changes relevant to the delivered behavior.

--- a/scripts/codex_review_gate.py
+++ b/scripts/codex_review_gate.py
@@ -14,6 +14,21 @@ BOT_ID = 199175422
 CONTEXT = "Codex review"
 
 
+def details_url(repo, explicit=None):
+    """Link status details to the actual evidence run, never back to the PR."""
+    url = explicit
+    if not url and os.environ.get("GITHUB_RUN_ID"):
+        url = f"https://github.com/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+    if not url or not re.fullmatch(
+        r"https://github\.com/" + re.escape(repo) + r"/actions/runs/\d+(?:/job/\d+)?",
+        url,
+    ):
+        raise ValueError(
+            "Publishing requires an Actions run URL (--details-url for local bootstrap)"
+        )
+    return url
+
+
 def trusted(value):
     user = value.get("user", {})
     return user.get("id") == BOT_ID and user.get("type") == "Bot"
@@ -170,7 +185,11 @@ def main():
     parser.add_argument("--repo", required=True)
     parser.add_argument("--pr", type=int)
     parser.add_argument("--publish", action="store_true")
+    parser.add_argument(
+        "--details-url", help="Actual evidence Actions run URL for local bootstrap"
+    )
     args = parser.parse_args()
+    target = details_url(args.repo, args.details_url) if args.publish else None
     numbers = (
         [args.pr]
         if args.pr
@@ -185,10 +204,19 @@ def main():
                     "state": "pending",
                     "context": CONTEXT,
                     "description": "Checking external review evidence",
+                    "target_url": target,
                 },
             )
         sha, state, reason = inspect(args.repo, number)
         print(json.dumps({"pr": number, "sha": sha, "state": state, "reason": reason}))
+        if os.environ.get("GITHUB_STEP_SUMMARY"):
+            with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+                summary.write(
+                    f"### Codex review · PR #{number}\n\n"
+                    f"- Reviewed head: `{sha}`\n- Gate: **{state}**\n- Reason: {reason}\n\n"
+                    "This job inspects evidence. A successful job alone is not review approval; "
+                    "the required **Codex review** status must be successful.\n\n"
+                )
         if args.publish:
             # Write only to the inspected SHA. A concurrent push gets no success
             # status and must independently pass a new evaluation.
@@ -198,7 +226,7 @@ def main():
                     "state": state,
                     "context": CONTEXT,
                     "description": reason[:140],
-                    "target_url": f"https://github.com/{args.repo}/pull/{number}",
+                    "target_url": target,
                 },
             )
 

--- a/scripts/codex_review_gate.py
+++ b/scripts/codex_review_gate.py
@@ -1,0 +1,207 @@
+"""Fail-closed adapter for Codex's current GitHub summary/reaction protocol.
+
+Only trusted default-branch code may run this with statuses:write. Never execute
+PR code. Unknown protocol changes leave the status pending, never approved.
+"""
+
+import argparse
+import json
+import os
+import re
+import urllib.request
+
+BOT_ID = 199175422
+CONTEXT = "Codex review"
+
+
+def trusted(value):
+    user = value.get("user", {})
+    return user.get("id") == BOT_ID and user.get("type") == "Bot"
+
+
+def evaluate(sha, comments, reactions, unresolved, reviews=()):
+    if unresolved:
+        return "pending", "Resolve review conversations and obtain a clean re-review"
+    marker = f"<!-- codex-review-head:{sha} -->"
+    requests = [
+        c for c in comments if "@codex review" in c.get("body", "") and not trusted(c)
+    ]
+    if not requests:
+        return "pending", "Awaiting a Codex review request bound to this commit"
+    request = max(requests, key=lambda c: c["id"])
+    if request.get("updated_at") != request.get("created_at"):
+        return "pending", "Post a new unedited review request"
+    summaries = [
+        c
+        for c in comments
+        if trusted(c)
+        and c.get("body", "").startswith("<!-- codex-pull-request-review-summary -->")
+    ]
+    if not summaries:
+        return "pending", "Waiting for Codex to start reviewing"
+    summary = max(summaries, key=lambda c: c["id"])
+    if summary["updated_at"] < request["created_at"]:
+        return "pending", "Waiting for a fresh review summary"
+    rows = [
+        line
+        for line in summary["body"].splitlines()
+        if "**Code Review**" in line and line.startswith("|")
+    ]
+    if len(rows) != 1:
+        return "pending", "Unrecognized Codex review summary; maintainer action needed"
+    columns = rows[0].split("|")
+    if len(columns) < 5:
+        return "pending", "Unrecognized Codex review summary; maintainer action needed"
+    commit = re.fullmatch(r"\s*`([0-9a-f]{7,40})`\s*", columns[3])
+    if not commit or not sha.startswith(commit[1]):
+        return "pending", "Codex has not reviewed the latest commit"
+    if "✅ **Completed**" not in columns[2]:
+        return "pending", "Codex review is running or has not completed successfully"
+    # Codex currently emits either a thumbs-up or an explicit clean-result
+    # comment. The latter carries its own reviewed commit; match its exact
+    # observed protocol, never an arbitrary mention of 'no issues'.
+    clean = [
+        c
+        for c in comments
+        if trusted(c)
+        and c.get("created_at", "") >= request["created_at"]
+        and c.get("updated_at") == c.get("created_at")
+        and c.get("body", "").startswith(
+            "Codex Review: Didn't find any major issues. Can't wait for the next one!\n\n"
+        )
+        and re.search(
+            r"\*\*Reviewed commit:\*\* `" + re.escape(sha[:10]) + r"`(?:\n|$)",
+            c["body"],
+        )
+    ]
+    positive = marker in request["body"] and any(
+        trusted(r) and r.get("content") == "+1"
+        for r in reactions.get(request["id"], [])
+    )
+    if not positive and not clean:
+        return "pending", "Review completed; awaiting Codex's clean-review confirmation"
+    # A later review with findings invalidates an older clean result even if
+    # somebody resolves its threads without obtaining another clean review.
+    signal_time = max((c["created_at"] for c in clean), default=request["created_at"])
+    if any(
+        trusted(r)
+        and r.get("submitted_at", "") >= signal_time
+        and r.get("state") in {"COMMENTED", "CHANGES_REQUESTED"}
+        for r in reviews
+    ):
+        return "pending", "Obtain a new clean review after the latest review findings"
+    return "success", "Codex clean review confirmed for latest commit; threads resolved"
+
+
+def api(path, data=None):
+    request = urllib.request.Request(
+        "https://api.github.com/" + path,
+        data=json.dumps(data).encode() if data is not None else None,
+        headers={
+            "Authorization": "Bearer " + os.environ["GH_TOKEN"],
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def pages(path):
+    result = []
+    for page in range(1, 101):
+        batch = api(f"{path}{'&' if '?' in path else '?'}per_page=100&page={page}")
+        result.extend(batch)
+        if len(batch) < 100:
+            return result
+    raise RuntimeError("Pagination limit exceeded; refusing incomplete evidence")
+
+
+def threads(repo, number):
+    owner, name = repo.split("/")
+    cursor = None
+    unresolved = False
+    while True:
+        result = api(
+            "graphql",
+            {
+                "query": """query($owner:String!,$name:String!,$number:Int!,$cursor:String){
+          repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$cursor){
+          nodes{isResolved} pageInfo{hasNextPage endCursor}}}}}""",
+                "variables": {
+                    "owner": owner,
+                    "name": name,
+                    "number": number,
+                    "cursor": cursor,
+                },
+            },
+        )
+        if result.get("errors"):
+            raise RuntimeError("Cannot retrieve complete review threads")
+        connection = result["data"]["repository"]["pullRequest"]["reviewThreads"]
+        unresolved |= any(not node["isResolved"] for node in connection["nodes"])
+        if not connection["pageInfo"]["hasNextPage"]:
+            return unresolved
+        cursor = connection["pageInfo"]["endCursor"]
+
+
+def inspect(repo, number):
+    pr = api(f"repos/{repo}/pulls/{number}")
+    sha = pr["head"]["sha"]
+    comments = pages(f"repos/{repo}/issues/{number}/comments")
+    matching = [
+        c for c in comments if f"<!-- codex-review-head:{sha} -->" in c.get("body", "")
+    ]
+    reactions = {}
+    if matching:
+        latest = max(matching, key=lambda c: c["id"])
+        reactions[latest["id"]] = pages(
+            f"repos/{repo}/issues/comments/{latest['id']}/reactions"
+        )
+    reviews = pages(f"repos/{repo}/pulls/{number}/reviews")
+    state, reason = evaluate(sha, comments, reactions, threads(repo, number), reviews)
+    if pr["draft"] or pr["state"] != "open":
+        state, reason = "pending", "PR must be open and ready for review"
+    return sha, state, reason
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr", type=int)
+    parser.add_argument("--publish", action="store_true")
+    args = parser.parse_args()
+    numbers = (
+        [args.pr]
+        if args.pr
+        else [p["number"] for p in pages(f"repos/{args.repo}/pulls?state=open")]
+    )
+    for number in numbers:
+        if args.publish:
+            current = api(f"repos/{args.repo}/pulls/{number}")["head"]["sha"]
+            api(
+                f"repos/{args.repo}/statuses/{current}",
+                {
+                    "state": "pending",
+                    "context": CONTEXT,
+                    "description": "Checking external review evidence",
+                },
+            )
+        sha, state, reason = inspect(args.repo, number)
+        print(json.dumps({"pr": number, "sha": sha, "state": state, "reason": reason}))
+        if args.publish:
+            # Write only to the inspected SHA. A concurrent push gets no success
+            # status and must independently pass a new evaluation.
+            api(
+                f"repos/{args.repo}/statuses/{sha}",
+                {
+                    "state": state,
+                    "context": CONTEXT,
+                    "description": reason[:140],
+                    "target_url": f"https://github.com/{args.repo}/pull/{number}",
+                },
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codex_review_gate.py
+++ b/scripts/codex_review_gate.py
@@ -111,7 +111,10 @@ def evaluate(sha, comments, reactions, unresolved, reviews=()):
     signal_time = max((c["created_at"] for c in clean), default=request["created_at"])
     if any(
         trusted(r)
-        and r.get("submitted_at", "") >= signal_time
+        and (
+            not r.get("updated_at")
+            or max(r.get("submitted_at") or "", r["updated_at"]) >= signal_time
+        )
         and r.get("state") in {"COMMENTED", "CHANGES_REQUESTED", "DISMISSED"}
         for r in reviews
     ):
@@ -147,7 +150,8 @@ def threads(repo, number):
     owner, name = repo.split("/")
     cursor = None
     unresolved = False
-    while True:
+    seen = set()
+    for _ in range(100):
         result = api(
             "graphql",
             {
@@ -169,6 +173,64 @@ def threads(repo, number):
         if not connection["pageInfo"]["hasNextPage"]:
             return unresolved
         cursor = connection["pageInfo"]["endCursor"]
+        if not cursor or cursor in seen:
+            raise RuntimeError("Review-thread pagination did not advance")
+        seen.add(cursor)
+    raise RuntimeError("Review-thread pagination limit exceeded")
+
+
+def review_history(repo, number):
+    owner, name = repo.split("/")
+    cursor = None
+    seen = set()
+    reviews = []
+    for _ in range(100):
+        response = api(
+            "graphql",
+            {
+                "query": """query($owner:String!,$name:String!,$number:Int!,$cursor:String){
+          repository(owner:$owner,name:$name){pullRequest(number:$number){reviews(first:100,after:$cursor){
+          nodes{submittedAt updatedAt state author{__typename ... on Bot{databaseId} ... on User{databaseId}}}
+          pageInfo{hasNextPage endCursor}}}}}""",
+                "variables": {
+                    "owner": owner,
+                    "name": name,
+                    "number": number,
+                    "cursor": cursor,
+                },
+            },
+        )
+        if response.get("errors"):
+            raise RuntimeError("Cannot retrieve complete review history")
+        connection = response["data"]["repository"]["pullRequest"]["reviews"]
+        for review in connection["nodes"]:
+            author = review.get("author") or {}
+            reviews.append(
+                {
+                    "user": {
+                        "id": author.get("databaseId"),
+                        "type": author.get("__typename"),
+                    },
+                    "state": review["state"],
+                    "submitted_at": review["submittedAt"],
+                    "updated_at": review["updatedAt"],
+                }
+            )
+        if not connection["pageInfo"]["hasNextPage"]:
+            break
+        cursor = connection["pageInfo"]["endCursor"]
+        if not cursor or cursor in seen:
+            raise RuntimeError("Review-history pagination did not advance")
+        seen.add(cursor)
+    else:
+        raise RuntimeError("Review-history pagination limit exceeded")
+    # Inline edits may not change their parent review's timestamp. Treat them
+    # as findings too, even if the conversation was previously resolved.
+    for comment in pages(f"repos/{repo}/pulls/{number}/comments"):
+        reviews.append(
+            {**comment, "state": "COMMENTED", "submitted_at": comment["created_at"]}
+        )
+    return reviews
 
 
 def inspect(repo, number):
@@ -187,9 +249,12 @@ def inspect(repo, number):
         reactions[latest["id"]] = pages(
             f"repos/{repo}/issues/comments/{latest['id']}/reactions"
         )
-    reviews = pages(f"repos/{repo}/pulls/{number}/reviews")
+    reviews = review_history(repo, number)
     state, reason = evaluate(sha, comments, reactions, threads(repo, number), reviews)
-    if pr["draft"] or pr["state"] != "open":
+    current = api(f"repos/{repo}/pulls/{number}")
+    if current["head"]["sha"] != sha:
+        state, reason = "pending", "PR head changed during inspection; retry required"
+    elif current["draft"] or current["state"] != "open":
         state, reason = "pending", "PR must be open and ready for review"
     return sha, state, reason
 
@@ -204,45 +269,126 @@ def main():
     )
     args = parser.parse_args()
     target = details_url(args.repo, args.details_url) if args.publish else None
-    numbers = (
-        [args.pr]
-        if args.pr
-        else [p["number"] for p in pages(f"repos/{args.repo}/pulls?state=open")]
-    )
-    for number in numbers:
-        if args.publish:
-            current = api(f"repos/{args.repo}/pulls/{number}")["head"]["sha"]
+    if args.publish:
+        publish_reviews(args.repo, target, args.pr)
+    else:
+        numbers = (
+            [args.pr]
+            if args.pr
+            else [p["number"] for p in pages(f"repos/{args.repo}/pulls?state=open")]
+        )
+        for number in numbers:
+            report(number, *inspect(args.repo, number))
+
+
+def report(number, sha, state, reason):
+    print(json.dumps({"pr": number, "sha": sha, "state": state, "reason": reason}))
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+            summary.write(
+                f"### Codex review · PR #{number}\n\n"
+                f"- Inspected head: `{sha}`\n- Gate: **{state}**\n- Reason: {reason}\n\n"
+                "This job inspects evidence. A successful job alone is not review approval; "
+                "the required **Codex review** status must be successful.\n\n"
+            )
+
+
+def latest_status(repo, sha):
+    for page in range(1, 101):
+        batch = api(f"repos/{repo}/commits/{sha}/statuses?per_page=100&page={page}")
+        for status in batch:
+            if status.get("context", "").casefold() == CONTEXT.casefold():
+                return status
+        if len(batch) < 100:
+            return None
+    raise RuntimeError("Status pagination limit exceeded")
+
+
+def publish_reviews(repo, target, only_pr=None):
+    # Commit statuses are shared by every PR with the same SHA. Always discover
+    # all open PRs, even for a scoped refresh, and aggregate their evidence.
+    pulls = pages(f"repos/{repo}/pulls?state=open")
+    groups = {}
+    for pr in pulls:
+        groups.setdefault(pr["head"]["sha"], []).append(pr["number"])
+    if only_pr is not None:
+        groups = {sha: numbers for sha, numbers in groups.items() if only_pr in numbers}
+        if not groups:
+            raise RuntimeError("Requested PR is not open; no status published")
+
+    def publish(sha, state, reason):
+        description = reason[:140]
+        try:
+            previous = latest_status(repo, sha)
+        except Exception:  # noqa: BLE001 - never preserve approval on incomplete status evidence
             api(
-                f"repos/{args.repo}/statuses/{current}",
+                f"repos/{repo}/statuses/{sha}",
                 {
                     "state": "pending",
                     "context": CONTEXT,
-                    "description": "Checking external review evidence",
+                    "description": "Status history unavailable; retry required",
                     "target_url": target,
                 },
             )
-        sha, state, reason = inspect(args.repo, number)
-        print(json.dumps({"pr": number, "sha": sha, "state": state, "reason": reason}))
-        if os.environ.get("GITHUB_STEP_SUMMARY"):
-            with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
-                summary.write(
-                    f"### Codex review · PR #{number}\n\n"
-                    f"- Reviewed head: `{sha}`\n- Gate: **{state}**\n- Reason: {reason}\n\n"
-                    "This job inspects evidence. A successful job alone is not review approval; "
-                    "the required **Codex review** status must be successful.\n\n"
+            raise RuntimeError("Status history could not be verified") from None
+        # GitHub allows only 1,000 statuses per SHA/context. A scheduled refresh
+        # with the same result must not consume another entry just to change its URL.
+        if (
+            previous
+            and previous["state"] == state
+            and previous.get("description") == description
+        ):
+            return
+        api(
+            f"repos/{repo}/statuses/{sha}",
+            {
+                "state": state,
+                "context": CONTEXT,
+                "description": description,
+                "target_url": target,
+            },
+        )
+
+    failures = False
+    for sha, numbers in groups.items():
+        outcomes = []
+        for number in numbers:
+            try:
+                inspected, state, reason = inspect(repo, number)
+                if inspected != sha:
+                    state, reason = (
+                        "pending",
+                        "Head changed since discovery; retry required",
+                    )
+            except Exception:  # noqa: BLE001 - isolate malformed/API evidence per PR; fail run below
+                # Keep this head pending, but inspect the remaining groups.
+                failures = True
+                state, reason = (
+                    "pending",
+                    "Evidence API inspection failed; retry required",
                 )
-        if args.publish:
-            # Write only to the inspected SHA. A concurrent push gets no success
-            # status and must independently pass a new evaluation.
-            api(
-                f"repos/{args.repo}/statuses/{sha}",
-                {
-                    "state": state,
-                    "context": CONTEXT,
-                    "description": reason[:140],
-                    "target_url": target,
-                },
-            )
+            report(number, sha, state, reason)
+            outcomes.append((state, reason))
+        blocked = next((result for result in outcomes if result[0] != "success"), None)
+        state, reason = blocked or (
+            "success",
+            "All open PRs for this commit have verified clean Codex review",
+        )
+        try:
+            publish(sha, state, reason)
+        except Exception:  # noqa: BLE001 - a publication failure must not abandon other heads
+            failures = True
+            for number in numbers:
+                report(
+                    number,
+                    sha,
+                    "pending",
+                    "Status publication failed; do not merge until a successful refresh",
+                )
+    if failures:
+        raise RuntimeError(
+            "Review refresh incomplete; do not merge until a successful retry"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/codex_review_gate.py
+++ b/scripts/codex_review_gate.py
@@ -112,7 +112,7 @@ def evaluate(sha, comments, reactions, unresolved, reviews=()):
     if any(
         trusted(r)
         and r.get("submitted_at", "") >= signal_time
-        and r.get("state") in {"COMMENTED", "CHANGES_REQUESTED"}
+        and r.get("state") in {"COMMENTED", "CHANGES_REQUESTED", "DISMISSED"}
         for r in reviews
     ):
         return "pending", "Obtain a new clean review after the latest review findings"

--- a/scripts/codex_review_gate.py
+++ b/scripts/codex_review_gate.py
@@ -34,13 +34,24 @@ def trusted(value):
     return user.get("id") == BOT_ID and user.get("type") == "Bot"
 
 
+def review_request(comment):
+    return comment.get("author_association") in {
+        "OWNER",
+        "MEMBER",
+        "COLLABORATOR",
+    } and bool(
+        re.fullmatch(
+            r"@codex review(?:\n<!-- codex-review-head:[0-9a-f]{40} -->)?",
+            comment.get("body", "").strip(),
+        )
+    )
+
+
 def evaluate(sha, comments, reactions, unresolved, reviews=()):
     if unresolved:
         return "pending", "Resolve review conversations and obtain a clean re-review"
     marker = f"<!-- codex-review-head:{sha} -->"
-    requests = [
-        c for c in comments if "@codex review" in c.get("body", "") and not trusted(c)
-    ]
+    requests = [c for c in comments if review_request(c)]
     if not requests:
         return "pending", "Awaiting a Codex review request bound to this commit"
     request = max(requests, key=lambda c: c["id"])
@@ -165,7 +176,10 @@ def inspect(repo, number):
     sha = pr["head"]["sha"]
     comments = pages(f"repos/{repo}/issues/{number}/comments")
     matching = [
-        c for c in comments if f"<!-- codex-review-head:{sha} -->" in c.get("body", "")
+        c
+        for c in comments
+        if review_request(c)
+        and f"<!-- codex-review-head:{sha} -->" in c.get("body", "")
     ]
     reactions = {}
     if matching:

--- a/scripts/tests/test_codex_review_gate.py
+++ b/scripts/tests/test_codex_review_gate.py
@@ -1,6 +1,32 @@
 import unittest
+from unittest.mock import patch
 
-from scripts.codex_review_gate import BOT_ID, evaluate
+from scripts.codex_review_gate import BOT_ID, details_url, evaluate
+
+
+class StatusLinks(unittest.TestCase):
+    @patch.dict("os.environ", {"GITHUB_RUN_ID": "123"}, clear=True)
+    def test_actions_links_to_its_run(self):
+        self.assertEqual(
+            details_url("owner/repo"), "https://github.com/owner/repo/actions/runs/123"
+        )
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_local_requires_real_run(self):
+        with self.assertRaises(ValueError):
+            details_url("owner/repo")
+
+    def test_rejects_pr_loop(self):
+        with self.assertRaises(ValueError):
+            details_url("owner/repo", "https://github.com/owner/repo/pull/37")
+
+    def test_local_can_link_evidence_job(self):
+        self.assertEqual(
+            details_url(
+                "owner/repo", "https://github.com/owner/repo/actions/runs/123/job/456"
+            ),
+            "https://github.com/owner/repo/actions/runs/123/job/456",
+        )
 
 
 class ReviewEvidence(unittest.TestCase):

--- a/scripts/tests/test_codex_review_gate.py
+++ b/scripts/tests/test_codex_review_gate.py
@@ -1,0 +1,141 @@
+import unittest
+
+from scripts.codex_review_gate import BOT_ID, evaluate
+
+
+class ReviewEvidence(unittest.TestCase):
+    def setUp(self):
+        self.sha = "a" * 40
+        self.bot = {"id": BOT_ID, "type": "Bot"}
+        self.request = {
+            "id": 10,
+            "body": "@codex review\n<!-- codex-review-head:" + self.sha + " -->",
+            "created_at": "2026-09-08T10:00:00Z",
+            "updated_at": "2026-09-08T10:00:00Z",
+        }
+        self.summary = {
+            "id": 11,
+            "user": self.bot,
+            "updated_at": "2026-09-08T10:01:00Z",
+            "body": "<!-- codex-pull-request-review-summary -->\n| 📝 **Code Review** | ✅ **Completed** | `aaaaaaa` | Manual request |",
+        }
+        self.reactions = {10: [{"user": self.bot, "content": "+1"}]}
+
+    def result(self, unresolved=False):
+        return evaluate(
+            self.sha, [self.request, self.summary], self.reactions, unresolved
+        )[0]
+
+    def test_edited_request(self):
+        self.request["updated_at"] = "2026-09-08T10:02:00Z"
+        self.assertEqual(self.result(), "pending")
+
+    def test_clean(self):
+        self.assertEqual(self.result(), "success")
+
+    def test_unresolved(self):
+        self.assertEqual(self.result(True), "pending")
+
+    def test_spoofed_summary(self):
+        self.summary["user"] = {"id": 1, "type": "User"}
+        self.assertEqual(self.result(), "pending")
+
+    def test_spoofed_reaction(self):
+        self.reactions[10][0]["user"] = {"id": 1, "type": "User"}
+        self.assertEqual(self.result(), "pending")
+
+    def test_stale_commit(self):
+        self.summary["body"] = self.summary["body"].replace("aaaaaaa", "bbbbbbb")
+        self.assertEqual(self.result(), "pending")
+
+    def test_running(self):
+        self.summary["body"] = self.summary["body"].replace(
+            "✅ **Completed**", "🔄 **Running**"
+        )
+        self.assertEqual(self.result(), "pending")
+
+    def test_findings_without_clean_signal(self):
+        self.reactions = {}
+        self.assertEqual(self.result(), "pending")
+
+    def test_stale_summary(self):
+        self.summary["updated_at"] = "2026-09-08T09:00:00Z"
+        self.assertEqual(self.result(), "pending")
+
+    def test_new_commit_requires_new_request(self):
+        self.sha = "b" * 40
+        self.assertEqual(self.result(), "pending")
+
+    def test_unknown_format(self):
+        self.summary["body"] = "Unexpected"
+        self.assertEqual(self.result(), "pending")
+
+    def clean_comment(self):
+        return {
+            "id": 12,
+            "user": self.bot,
+            "created_at": "2026-09-08T10:00:59Z",
+            "updated_at": "2026-09-08T10:00:59Z",
+            "body": "Codex Review: Didn't find any major issues. Can't wait for the next one!\n\n**Reviewed commit:** `aaaaaaaaaa`\n",
+        }
+
+    def test_explicit_clean_comment(self):
+        self.request["body"] = "@codex review"
+        self.assertEqual(
+            evaluate(
+                self.sha, [self.request, self.summary, self.clean_comment()], {}, False
+            )[0],
+            "success",
+        )
+
+    def test_wrong_head_clean_comment(self):
+        comment = self.clean_comment()
+        comment["body"] = comment["body"].replace("aaaaaaaaaa", "bbbbbbbbbb")
+        self.assertEqual(
+            evaluate(self.sha, [self.request, self.summary, comment], {}, False)[0],
+            "pending",
+        )
+
+    def test_forged_clean_comment(self):
+        comment = self.clean_comment()
+        comment["user"] = {"id": 1, "type": "User"}
+        self.assertEqual(
+            evaluate(self.sha, [self.request, self.summary, comment], {}, False)[0],
+            "pending",
+        )
+
+    def test_new_unmarked_request_invalidates_old_reaction(self):
+        newer = dict(
+            self.request,
+            id=13,
+            body="@codex review",
+            created_at="2026-09-08T10:02:00Z",
+            updated_at="2026-09-08T10:02:00Z",
+        )
+        self.assertEqual(
+            evaluate(
+                self.sha, [self.request, self.summary, newer], self.reactions, False
+            )[0],
+            "pending",
+        )
+
+    def test_later_findings_invalidate_clean_comment(self):
+        review = {
+            "user": self.bot,
+            "submitted_at": "2026-09-08T10:01:00Z",
+            "state": "COMMENTED",
+        }
+        self.assertEqual(
+            evaluate(
+                self.sha,
+                [self.request, self.summary, self.clean_comment()],
+                {},
+                False,
+                [review],
+            )[0],
+            "pending",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_codex_review_gate.py
+++ b/scripts/tests/test_codex_review_gate.py
@@ -217,3 +217,44 @@ class ReviewEvidence(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class EditedReviews(unittest.TestCase):
+    setUp = ReviewEvidence.setUp
+    clean_comment = ReviewEvidence.clean_comment
+
+    def test_edit_of_old_review_invalidates_later_clean_signal(self):
+        review = {
+            "user": self.bot,
+            "submitted_at": "2026-09-08T09:00:00Z",
+            "updated_at": "2026-09-08T10:02:00Z",
+            "state": "COMMENTED",
+        }
+        self.assertEqual(
+            evaluate(
+                self.sha,
+                [self.request, self.summary, self.clean_comment()],
+                {},
+                False,
+                [review],
+            )[0],
+            "pending",
+        )
+
+    def test_clean_signal_after_old_review_edit_can_pass(self):
+        review = {
+            "user": self.bot,
+            "submitted_at": "2026-09-08T09:00:00Z",
+            "updated_at": "2026-09-08T09:30:00Z",
+            "state": "COMMENTED",
+        }
+        self.assertEqual(
+            evaluate(
+                self.sha,
+                [self.request, self.summary, self.clean_comment()],
+                {},
+                False,
+                [review],
+            )[0],
+            "success",
+        )

--- a/scripts/tests/test_codex_review_gate.py
+++ b/scripts/tests/test_codex_review_gate.py
@@ -35,6 +35,7 @@ class ReviewEvidence(unittest.TestCase):
         self.bot = {"id": BOT_ID, "type": "Bot"}
         self.request = {
             "id": 10,
+            "author_association": "OWNER",
             "body": "@codex review\n<!-- codex-review-head:" + self.sha + " -->",
             "created_at": "2026-09-08T10:00:00Z",
             "updated_at": "2026-09-08T10:00:00Z",
@@ -58,6 +59,40 @@ class ReviewEvidence(unittest.TestCase):
 
     def test_clean(self):
         self.assertEqual(self.result(), "success")
+
+    def test_outsider_cannot_reset_review(self):
+        outsider = dict(
+            self.request,
+            id=20,
+            author_association="NONE",
+            created_at="2026-09-08T11:00:00Z",
+            updated_at="2026-09-08T11:00:00Z",
+        )
+        self.assertEqual(
+            evaluate(
+                self.sha, [self.request, self.summary, outsider], self.reactions, False
+            )[0],
+            "success",
+        )
+
+    def test_incidental_mention_cannot_reset_review(self):
+        prose = dict(
+            self.request,
+            id=20,
+            body="Remember to use @codex review before merging",
+            created_at="2026-09-08T11:00:00Z",
+            updated_at="2026-09-08T11:00:00Z",
+        )
+        self.assertEqual(
+            evaluate(
+                self.sha, [self.request, self.summary, prose], self.reactions, False
+            )[0],
+            "success",
+        )
+
+    def test_unknown_association_cannot_authorize_review(self):
+        self.request.pop("author_association")
+        self.assertEqual(self.result(), "pending")
 
     def test_unresolved(self):
         self.assertEqual(self.result(True), "pending")

--- a/scripts/tests/test_codex_review_gate.py
+++ b/scripts/tests/test_codex_review_gate.py
@@ -180,6 +180,23 @@ class ReviewEvidence(unittest.TestCase):
             "pending",
         )
 
+    def test_dismissed_later_findings_still_require_clean_review(self):
+        review = {
+            "user": self.bot,
+            "submitted_at": "2026-09-08T10:01:00Z",
+            "state": "DISMISSED",
+        }
+        self.assertEqual(
+            evaluate(
+                self.sha,
+                [self.request, self.summary, self.clean_comment()],
+                {},
+                False,
+                [review],
+            )[0],
+            "pending",
+        )
+
     def test_later_findings_invalidate_clean_comment(self):
         review = {
             "user": self.bot,

--- a/scripts/tests/test_review_api.py
+++ b/scripts/tests/test_review_api.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import patch
+
+from scripts import codex_review_gate as gate
+
+
+class EvidenceApi(unittest.TestCase):
+    def connection(self, nodes, more=False, cursor=None):
+        return {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": nodes,
+                            "pageInfo": {"hasNextPage": more, "endCursor": cursor},
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_rest_reads_last_page(self):
+        with patch.object(gate, "api", side_effect=[[{}] * 100, [{"id": 101}]]) as api:
+            self.assertEqual(len(gate.pages("example")), 101)
+            self.assertIn("page=2", api.call_args.args[0])
+
+    def test_later_rest_page_failure_is_not_partial_success(self):
+        with (
+            patch.object(gate, "api", side_effect=[[{}] * 100, RuntimeError("API")]),
+            self.assertRaises(RuntimeError),
+        ):
+            gate.pages("example")
+
+    def test_unresolved_thread_on_second_page(self):
+        with patch.object(
+            gate,
+            "api",
+            side_effect=[
+                self.connection([{"isResolved": True}], True, "next"),
+                self.connection([{"isResolved": False}]),
+            ],
+        ):
+            self.assertTrue(gate.threads("owner/repo", 1))
+
+    def test_graphql_errors_reject_partial_data(self):
+        with (
+            patch.object(
+                gate, "api", return_value={"errors": [{"message": "unavailable"}]}
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            gate.threads("owner/repo", 1)
+
+    def test_repeated_graphql_cursor_fails_closed(self):
+        with (
+            patch.object(gate, "api", return_value=self.connection([], True, "same")),
+            self.assertRaises(RuntimeError),
+        ):
+            gate.threads("owner/repo", 1)
+
+    def test_push_during_inspection_invalidates_result(self):
+        old = {"head": {"sha": "a" * 40}, "draft": False, "state": "open"}
+        new = dict(old, head={"sha": "b" * 40})
+        with (
+            patch.object(gate, "api", side_effect=[old, new]),
+            patch.object(gate, "pages", return_value=[]),
+            patch.object(gate, "threads", return_value=False),
+            patch.object(gate, "review_history", return_value=[]),
+            patch.object(gate, "evaluate", return_value=("success", "clean")),
+        ):
+            self.assertEqual(gate.inspect("owner/repo", 1)[1], "pending")
+
+    def test_draft_transition_during_inspection_invalidates_result(self):
+        old = {"head": {"sha": "a" * 40}, "draft": False, "state": "open"}
+        new = dict(old, draft=True)
+        with (
+            patch.object(gate, "api", side_effect=[old, new]),
+            patch.object(gate, "pages", return_value=[]),
+            patch.object(gate, "threads", return_value=False),
+            patch.object(gate, "review_history", return_value=[]),
+            patch.object(gate, "evaluate", return_value=("success", "clean")),
+        ):
+            self.assertEqual(gate.inspect("owner/repo", 1)[1], "pending")

--- a/scripts/tests/test_review_publication.py
+++ b/scripts/tests/test_review_publication.py
@@ -1,0 +1,126 @@
+import unittest
+from unittest.mock import patch
+
+from scripts import codex_review_gate as gate
+
+
+class Publication(unittest.TestCase):
+    def run_gate(
+        self,
+        heads,
+        outcomes,
+        repeat=1,
+        only_pr=None,
+        fail_publish=None,
+        fail_history=False,
+    ):
+        self.statuses = []
+        self.errors = []
+        history = {}
+        pulls = [{"number": n, "head": {"sha": sha}} for n, sha in heads.items()]
+
+        def api(path, data=None):
+            if "/commits/" in path:
+                if fail_history:
+                    raise RuntimeError("Status history unavailable")
+                return history.get(path.split("/commits/")[1].split("/")[0], [])
+            if "/statuses/" in path:
+                if path.rsplit("/", 1)[-1] == fail_publish:
+                    raise RuntimeError("Status write failed")
+                self.statuses.append((path.rsplit("/", 1)[-1], data["state"]))
+                history[path.rsplit("/", 1)[-1]] = [dict(data)]
+                return {}
+            return {
+                "head": {"sha": heads[int(path.rsplit("/", 1)[-1])]},
+                "state": "open",
+                "draft": False,
+            }
+
+        def inspect(repo, number):
+            value = outcomes[number]
+            if isinstance(value, Exception):
+                raise value
+            return (
+                value
+                if isinstance(value, tuple)
+                else (heads[number], value, "test evidence")
+            )
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch.object(gate, "pages", return_value=pulls),
+            patch.object(gate, "api", side_effect=api),
+            patch.object(gate, "inspect", side_effect=inspect),
+            patch.object(gate, "report"),
+            patch(
+                "sys.argv",
+                [
+                    "gate",
+                    "--repo",
+                    "owner/repo",
+                    "--publish",
+                    "--details-url",
+                    "https://github.com/owner/repo/actions/runs/1",
+                ],
+            ),
+        ):
+            for _ in range(repeat):
+                try:
+                    gate.publish_reviews(
+                        "owner/repo",
+                        "https://github.com/owner/repo/actions/runs/1",
+                        only_pr,
+                    )
+                except RuntimeError as error:
+                    self.errors.append(error)
+
+    def test_api_failure_does_not_leave_other_heads_with_old_success(self):
+        self.run_gate(
+            {1: "a" * 40, 2: "b" * 40},
+            {1: RuntimeError("API unavailable"), 2: "pending"},
+        )
+        self.assertIn(("b" * 40, "pending"), self.statuses)
+
+    def test_prs_sharing_a_commit_cannot_overwrite_pending_with_success(self):
+        self.run_gate({1: "a" * 40, 2: "a" * 40}, {1: "pending", 2: "success"})
+        self.assertEqual(self.statuses[-1], ("a" * 40, "pending"))
+
+    def test_all_prs_sharing_commit_must_pass(self):
+        self.run_gate({1: "a" * 40, 2: "a" * 40}, {1: "success", 2: "success"})
+        self.assertEqual(self.statuses[-1], ("a" * 40, "success"))
+
+    def test_repeated_success_does_not_exhaust_status_limit(self):
+        self.run_gate({1: "a" * 40}, {1: "success"}, repeat=1001)
+        self.assertEqual(self.statuses, [("a" * 40, "success")])
+
+    def test_scoped_refresh_includes_sibling_prs_with_same_sha(self):
+        self.run_gate(
+            {1: "a" * 40, 2: "a" * 40}, {1: "success", 2: "pending"}, only_pr=1
+        )
+        self.assertEqual(self.statuses[-1], ("a" * 40, "pending"))
+
+    def test_changed_head_is_never_published_as_success(self):
+        self.run_gate({1: "a" * 40}, {1: ("b" * 40, "success", "changed")})
+        self.assertEqual(self.statuses, [("a" * 40, "pending")])
+
+    def test_failed_inspection_fails_run_and_still_processes_other_prs(self):
+        self.run_gate(
+            {1: "a" * 40, 2: "b" * 40}, {1: RuntimeError("API"), 2: "success"}
+        )
+        self.assertEqual(len(self.errors), 1)
+        self.assertIn(("a" * 40, "pending"), self.statuses)
+        self.assertIn(("b" * 40, "success"), self.statuses)
+
+    def test_failed_publication_does_not_abandon_other_heads(self):
+        self.run_gate(
+            {1: "a" * 40, 2: "b" * 40},
+            {1: "success", 2: "pending"},
+            fail_publish="a" * 40,
+        )
+        self.assertEqual(len(self.errors), 1)
+        self.assertIn(("b" * 40, "pending"), self.statuses)
+
+    def test_missing_status_history_cannot_publish_success(self):
+        self.run_gate({1: "a" * 40}, {1: "success"}, fail_history=True)
+        self.assertEqual(self.statuses, [("a" * 40, "pending")])
+        self.assertEqual(len(self.errors), 1)


### PR DESCRIPTION
## Summary
Translate verified Codex review evidence into a visible `Codex review` commit status. Validate the current commit, trusted reviewer, clean result and resolved discussions; publish status changes with links to the evidence Actions run.

## Issue
Refs #36. This PR targets #35's documentation branch; #35 then delivers the combined change to main. Main activation is completed through #35. Broader protection coverage and merge-button behaviour remain in Backlog under #38.

## Before / After
| Before | After |
| --- | --- |
| Codex results require manual inspection | Named pending/success status with a reason and evidence link |
| Old results could survive review edits or publication failures | Updated review timestamps, isolated API failures and aggregated results for PRs sharing a commit |
| Every refresh appends statuses | Unchanged results avoid duplicate writes and GitHub's per-commit status limit |

## Acceptance criteria
- [x] Validate trusted current-head review evidence and reject unresolved or stale findings.
- [x] Include edited/dismissed reviews and edited inline comments.
- [x] Keep write-enabled execution on trusted default-branch code; use a permissionless review-event relay.
- [x] Cover publication failures, shared commits, pagination and repeated refreshes with regression tests.
- [x] Update template, skill, delivery guidance and self-review report.
- [ ] Obtain clean external review and passing CI on the final head.

## Testing
- Tested head: `1e72639ec21e7cd5f15a1c10a24405631bac7407`.
- 42 regression tests pass locally and in [review-gate CI](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34217507530), including live read-only GitHub evidence inspection.
- Ruff lint/format and `git diff --check` pass. All six workflow YAML files parse; action references are pinned and jobs have timeouts.
- Full self-review and reproduced findings: [CI self-review report](https://github.com/youneshenniwrites/fastapi-next-ecommerce/blob/1e72639ec21e7cd5f15a1c10a24405631bac7407/docs/ci-self-review.md).
- Application CI and external-review status are tracked in the PR checks; do not treat the successful inspection job as approval.

## Review
- Implementation review: self-review; distinct from external Codex review.
- Owner: @youneshenniwrites (assignee only)
- External reviewer: Codex Code Review
- [x] Previously reported findings addressed and threads resolved.
- [ ] Clean Codex review verified for the final head.
- [ ] All required CI verified for the final head.

## Deployment / Compatibility
No application deployment. The workflow becomes active only when the combined change reaches main through #35. Validate real approval evidence before replacing the human approval count; retain the other protections.

The gate adapts Codex's observed response format. Its Actions summary is a snapshot, not live Codex execution logs. If GitHub cannot accept status writes, the workflow fails but cannot remotely erase an old status; merging requires a fresh successful refresh and current evidence. Ticket acceptance is checked separately. The gate itself does not auto-merge PRs.
