### PR TITLE
feat(auth): add server-mediated customer sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Working in this repository
 
 The product has a FastAPI backend and a runnable Next.js catalog storefront.
-Customer sessions and checkout are still planned. Read
+Server-mediated customer sessions are implemented; account UI and checkout are planned. Read
 docs/plans/portfolio.md, docs/architecture.md, and docs/plans/roadmap.md before choosing work; update their
 factual status when a feature lands.
 
@@ -68,8 +68,7 @@ and the linked board for current work, the repository for versioned rules, and t
 Wiki for explanations. Every implementation PR needs an issue reference; use
 Closes #N only for a completed ticket. Update board status and verify acceptance,
 CI, PR disposition and relevant documentation before reporting completion.
-For customer sessions (#24), read docs/design/customer-sessions.md; it is a
-proposed design, not implemented behavior.
+For customer sessions (#24), read docs/design/customer-sessions.md; it documents the implemented handlers and remaining account UI work.
 
 ## External review requirement
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For a first API request, authentication, and Postman import, follow the
 can be downloaded even while the API is offline; executing requests requires the stack.
 
 For the storefront, run `make demo`, then `cd frontend && npm ci && npm run dev`
-with Node 24.20.0 and npm 11.19.1. Open [localhost:3000](http://localhost:3000).
+with Node 24.20.0 and npm 11.19.1. Open [127.0.0.1:3000](http://127.0.0.1:3000).
 See [frontend setup](frontend/README.md). Re-run `make dev` after changing containerized code.
 
 ```sh
@@ -217,7 +217,7 @@ backup/restore, and rollback before provisioning. The old AWS Terraform in
 
 This is a [senior SWE portfolio project](docs/plans/portfolio.md).
 The next product steps are customer
-sessions, carts, orders, and sandbox payments. Follow the
+account screens, carts, orders, and sandbox payments. Follow the
 [ordered roadmap](docs/plans/roadmap.md) for the remaining work.
 
 ## Repository map

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -89,7 +89,11 @@ def login(
         subject=user.id, expires_delta=access_token_expires
     )
 
-    return {"access_token": access_token, "token_type": "bearer"}
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "expires_in": int(access_token_expires.total_seconds()),
+    }
 
 
 @router.get(

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 class Token(BaseModel):
     access_token: str
     token_type: str = "bearer"
+    expires_in: int  # Lifetime in seconds; derived from the issued token configuration.
 
 
 class TokenPayload(BaseModel):

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -25,8 +25,11 @@ def test_register_login_and_me(client):
         data={"username": "new@example.com", "password": "password123"},
     )
     assert login.status_code == 200
+    assert login.json()["expires_in"] > 0
     token = login.json()["access_token"]
-    assert decode_access_token(token)["sub"] == str(response.json()["id"])
+    claims = decode_access_token(token)
+    assert claims["sub"] == str(response.json()["id"])
+    assert claims["exp"] - claims["iat"] == login.json()["expires_in"]
     me = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
     assert me.status_code == 200
     assert me.json()["email"] == "new@example.com"

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -14,7 +14,7 @@ make admin EMAIL=admin@example.com
 The admin command prompts twice for a private password (8–128 characters). There
 is no shared default password, command-line password option, or generated secret
 in output. Use the account in `/docs` through the login endpoint. Public signup
-cannot grant admin access. Start the storefront with cd frontend && npm ci && npm run dev; browse localhost:3000.
+cannot grant admin access. Start the storefront with cd frontend && npm ci && npm run dev; browse 127.0.0.1:3000.
 
 `make demo` seeds six products only when the catalog is empty. Reruns leave all
 existing products untouched, including changed names, prices and depleted stock.

--- a/docs/design/customer-sessions.md
+++ b/docs/design/customer-sessions.md
@@ -1,9 +1,15 @@
-# Customer sessions — proposal for issue #24
+# Customer sessions — issue #24
 
-Status: proposed, not implemented. This note defines the intended security and
-verification boundaries before account UI work (#25–27). FastAPI bearer auth
-already exists; Next.js customer sessions do not. Revise this note with actual
-routes, cookie settings and evidence when the implementation lands.
+Session handlers are implemented; account screens remain in #25–27.
+
+- POST `/api/session/login`: JSON email/password, returns authenticated: true.
+- GET `/api/session/me`: active profile or 401; upstream failure returns 503.
+- POST `/api/session/logout`: clears the session cookie.
+
+Every response is private/no-store. Configure APP_ORIGIN to the exact browser
+origin. Local loopback HTTP requires ALLOW_LOCAL_HTTP_SESSIONS=true; deployment
+uses HTTPS and __Host-session. No arbitrary redirect destination is supported:
+next/redirect login fields are rejected, and account UI owns local navigation.
 
 ## Flow and ownership
 
@@ -30,10 +36,11 @@ reject external, protocol-relative and malformed redirect targets.
 
 ## Expiry, failures and logout
 
-Cookie lifetime must not outlive the access token. The current token response has
-no expires_in value, so implementation must select and document an explicit
-lifetime source. If an unverified exp claim is read solely to bound cookie expiry,
-it must never establish authentication or authorization; FastAPI validates tokens.
+FastAPI now returns expires_in (seconds) from the configured issued-token lifetime.
+Next.js subtracts upstream elapsed time and a rounding margin before setting cookie
+Max-Age. Token expiry remains authoritative in FastAPI even if client clock or
+response delivery delays leave a stale browser cookie. No JWT claims are trusted
+or decoded by Next.js.
 Do not add a refresh-token flow implicitly. Expiry requires sign-in again.
 
 Resolve the profile through FastAPI, handling invalid/expired tokens and disabled

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -24,8 +24,9 @@ Purpose and priorities: [senior SWE portfolio plan](portfolio.md).
    See [demo guide](../demo.md); the catalog storefront is also implemented.
 2. Next.js catalog implemented: App Router, TypeScript, generated API contract,
    product list/detail, filtering, state handling and desktop/mobile browser checks.
-3. Customer frontend auth: login/register/profile, server-mediated secure session
-   handling, logout and error states. Keep authorization in FastAPI.
+3. Server-mediated session handlers implemented: login/profile/logout, HttpOnly
+   cookies and origin checks. Account login/register/profile UI remains in #25–27.
+   Keep authorization in FastAPI.
 4. Persistent carts: ownership, quantity changes/removal, stock checks, API and UI.
 5. Orders and checkout: price snapshots, authoritative totals, atomic inventory
    handling, idempotency, and concurrent last-item purchase tests.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,7 @@
 # Server-side only; never use NEXT_PUBLIC_ for credentials or private API URLs.
 API_BASE_URL=http://127.0.0.1:8000
+
+# Explicit browser origin; production must use its HTTPS origin.
+APP_ORIGIN=http://127.0.0.1:3000
+# Local loopback HTTP only; omit on Azure.
+ALLOW_LOCAL_HTTP_SESSIONS=true

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -20,5 +20,5 @@ Preserve loading, empty, error, not-found, out-of-stock and reduced-motion behav
 Verify keyboard access, mobile layout and automated accessibility checks. Product
 art is locally authored SVG illustration; unknown names use neutral fallback art.
 
-Customer sessions, cart, checkout and Azure deployment are still planned. Do not
+Server-mediated sessions are implemented; account UI, cart, checkout and Azure deployment remain planned. Do not
 present working purchase controls until the corresponding transaction exists.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,7 +15,7 @@ npm ci
 npm run dev
 ```
 
-Open http://localhost:3000. The server defaults to http://127.0.0.1:8000 for FastAPI.
+Open http://127.0.0.1:3000. The server defaults to http://127.0.0.1:8000 for FastAPI.
 To change it, set API_BASE_URL in an ignored .env.local; see .env.example. No CORS
 configuration is necessary: only the Next.js server calls FastAPI. Fetches are
 uncached and have a five-second timeout. Failed requests show a retryable state.
@@ -51,7 +51,7 @@ artwork. This is presentation metadata, not authoritative product data.
 
 The catalog currently loads at most 100 products and filters those loaded items;
 a notice appears at that limit. Server-side search/pagination is a future increment
-before a larger catalog. There are no customer sessions, carts, payments or purchase
+before a larger catalog. Session handlers are implemented; there are no account screens, carts, payments or purchase
 controls yet. Automated accessibility checks supplement manual keyboard/mobile
 review; they do not constitute a full accessibility certification.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -62,3 +62,16 @@ PORT and HOSTNAME environment variables to serve that package. CI archives the
 contents; after extraction use node server.js with API_BASE_URL configured.
 
 Azure deployment is not configured. See ../docs/ci.md for the delivery pipeline.
+
+## Customer session API
+
+Copy `.env.example` to `.env.local` for loopback development and open
+http://127.0.0.1:3000 (the origin must exactly match APP_ORIGIN). HTTPS deployments
+set APP_ORIGIN to their public origin and omit ALLOW_LOCAL_HTTP_SESSIONS.
+
+POST /api/session/login accepts JSON email/password; GET /api/session/me returns
+the active profile; POST /api/session/logout clears the HttpOnly cookie. Browser
+mutations require the configured Origin. All responses are private/no-store,
+return no bearer token in JSON and use bounded upstream requests. See
+[session design](../docs/design/customer-sessions.md) for errors, expiry and
+stateless logout limitations. Account forms are the next feature tickets.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -274,6 +274,10 @@
             "title": "Access Token",
             "type": "string"
           },
+          "expires_in": {
+            "title": "Expires In",
+            "type": "integer"
+          },
           "token_type": {
             "default": "bearer",
             "title": "Token Type",
@@ -281,7 +285,8 @@
           }
         },
         "required": [
-          "access_token"
+          "access_token",
+          "expires_in"
         ],
         "title": "Token",
         "type": "object"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
   use: { trace: "retain-on-failure", screenshot: "only-on-failure" },
   projects: [
     {
+      name: "sessions",
+      testMatch: "session.spec.ts",
+      use: {
+        baseURL: "http://127.0.0.1:3300",
+        trace: "off",
+        screenshot: "off",
+      },
+    },
+    {
       name: "desktop",
       testMatch: "catalog.spec.ts",
       use: { ...devices["Desktop Chrome"], baseURL: "http://127.0.0.1:3300" },
@@ -42,6 +51,8 @@ export default defineConfig({
       env: {
         API_BASE_URL: "http://127.0.0.1:18300",
         PORT: "3300",
+        APP_ORIGIN: "http://127.0.0.1:3300",
+        ALLOW_LOCAL_HTTP_SESSIONS: "true",
         HOSTNAME: "127.0.0.1",
       },
       reuseExistingServer: false,

--- a/frontend/src/app/api/session/login/route.ts
+++ b/frontend/src/app/api/session/login/route.ts
@@ -1,0 +1,1 @@
+export { login as POST } from "../../../../lib/session";

--- a/frontend/src/app/api/session/logout/route.ts
+++ b/frontend/src/app/api/session/logout/route.ts
@@ -1,0 +1,1 @@
+export { logout as POST } from "../../../../lib/session";

--- a/frontend/src/app/api/session/me/route.ts
+++ b/frontend/src/app/api/session/me/route.ts
@@ -1,0 +1,1 @@
+export { profile as GET } from "../../../../lib/session";

--- a/frontend/src/lib/api/schema.d.ts
+++ b/frontend/src/lib/api/schema.d.ts
@@ -229,6 +229,8 @@ export interface components {
         Token: {
             /** Access Token */
             access_token: string;
+            /** Expires In */
+            expires_in: number;
             /**
              * Token Type
              * @default bearer

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -1,0 +1,140 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { apiClient } from "./api/client";
+
+function policy() {
+  const raw = process.env.APP_ORIGIN;
+  if (!raw) throw new Error("APP_ORIGIN is required for sessions");
+  const origin = new URL(raw);
+  if (origin.origin !== raw || origin.username || origin.password)
+    throw new Error("APP_ORIGIN must be an origin");
+  const secure = origin.protocol === "https:";
+  if (
+    !secure &&
+    !(
+      origin.protocol === "http:" &&
+      ["localhost", "127.0.0.1", "[::1]"].includes(origin.hostname) &&
+      process.env.ALLOW_LOCAL_HTTP_SESSIONS === "true"
+    )
+  )
+    throw new Error(
+      "Sessions require HTTPS or explicit loopback development mode",
+    );
+  return {
+    origin: raw,
+    secure,
+    name: secure ? "__Host-session" : "local-session",
+  };
+}
+
+function reply(body: object, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "private, no-store",
+      Vary: "Cookie",
+    },
+  });
+}
+
+function clear(response: NextResponse, config: ReturnType<typeof policy>) {
+  response.cookies.set(config.name, "", {
+    httpOnly: true,
+    secure: config.secure,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+  return response;
+}
+
+export async function login(request: NextRequest) {
+  try {
+    const config = policy();
+    if (request.headers.get("origin") !== config.origin)
+      return reply({ error: "Origin rejected" }, 403);
+    if (!request.headers.get("content-type")?.startsWith("application/json"))
+      return reply({ error: "Expected JSON" }, 415);
+    let input;
+    try {
+      input = await request.json();
+    } catch {
+      return reply({ error: "Invalid JSON" }, 400);
+    }
+    if (
+      !input ||
+      typeof input.email !== "string" ||
+      typeof input.password !== "string" ||
+      !input.email ||
+      input.email.length > 254 ||
+      !input.password ||
+      input.password.length > 1024
+    )
+      return reply({ error: "Email and password are required" }, 400);
+    // No caller-controlled redirect is accepted. Account UI chooses its own local navigation.
+    if ("next" in input || "redirect" in input)
+      return reply({ error: "Redirect parameters are not supported" }, 400);
+    const started = Date.now();
+    const result = await apiClient().POST("/api/v1/auth/login", {
+      redirect: "error",
+      body: { username: input.email, password: input.password, scope: "" },
+      bodySerializer: (body) =>
+        new URLSearchParams(body as Record<string, string>).toString(),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+    if (result.response.status === 401)
+      return clear(reply({ error: "Invalid credentials" }, 401), config);
+    if (!result.data || result.response.status !== 200)
+      return reply({ error: "Authentication service unavailable" }, 503);
+    const { access_token, expires_in, token_type } = result.data;
+    const lifetime = Math.floor(expires_in - (Date.now() - started) / 1000) - 1;
+    if (
+      !access_token ||
+      token_type !== "bearer" ||
+      !Number.isSafeInteger(lifetime) ||
+      lifetime <= 0
+    )
+      return reply({ error: "Authentication service unavailable" }, 503);
+    const response = reply({ authenticated: true });
+    response.cookies.set(config.name, access_token, {
+      httpOnly: true,
+      secure: config.secure,
+      sameSite: "lax",
+      path: "/",
+      maxAge: lifetime,
+    });
+    return response;
+  } catch {
+    return reply({ error: "Authentication service unavailable" }, 503);
+  }
+}
+
+export async function profile(request: NextRequest) {
+  try {
+    const config = policy();
+    const token = request.cookies.get(config.name)?.value;
+    if (!token) return reply({ error: "Sign in required" }, 401);
+    const result = await apiClient().GET("/api/v1/auth/me", {
+      redirect: "error",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (result.response.status === 401)
+      return clear(reply({ error: "Sign in required" }, 401), config);
+    if (!result.data || result.response.status !== 200)
+      return reply({ error: "Authentication service unavailable" }, 503);
+    return reply(result.data);
+  } catch {
+    return reply({ error: "Authentication service unavailable" }, 503);
+  }
+}
+
+export async function logout(request: NextRequest) {
+  try {
+    const config = policy();
+    if (request.headers.get("origin") !== config.origin)
+      return reply({ error: "Origin rejected" }, 403);
+    return clear(reply({ authenticated: false }), config);
+  } catch {
+    return reply({ error: "Authentication service unavailable" }, 503);
+  }
+}

--- a/frontend/tests/browser/session.spec.ts
+++ b/frontend/tests/browser/session.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+test("real API login, private profile and logout without JS token exposure", async ({
+  page,
+  request,
+}) => {
+  const email = `session-${Date.now()}@example.com`;
+  const password = "test-only-password-123";
+  expect(
+    (
+      await request.post("http://127.0.0.1:18300/api/v1/auth/register", {
+        data: { email, password },
+      })
+    ).status(),
+  ).toBe(201);
+  await page.goto("/");
+  const login = await page.evaluate(
+    async ({ email, password }) => {
+      const r = await fetch("/api/session/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      return { status: r.status, body: await r.json() };
+    },
+    { email, password },
+  );
+  expect(login).toEqual({ status: 200, body: { authenticated: true } });
+  expect(await page.evaluate(() => document.cookie)).not.toContain("session");
+  expect(
+    await page.evaluate(() => ({
+      local: localStorage.length,
+      session: sessionStorage.length,
+    })),
+  ).toEqual({ local: 0, session: 0 });
+  const profile = await page.evaluate(async () => {
+    const r = await fetch("/api/session/me");
+    return {
+      status: r.status,
+      body: await r.json(),
+      cache: r.headers.get("cache-control"),
+    };
+  });
+  expect(profile.status).toBe(200);
+  expect(profile.body.email).toBe(email);
+  expect(profile.body.access_token).toBeUndefined();
+  expect(profile.cache).toContain("no-store");
+  expect(
+    await page.evaluate(
+      async () =>
+        (await fetch("/api/session/logout", { method: "POST" })).status,
+    ),
+  ).toBe(200);
+  expect(
+    await page.evaluate(async () => (await fetch("/api/session/me")).status),
+  ).toBe(401);
+  expect(
+    (
+      await request.post("/api/session/login", { data: { email, password } })
+    ).status(),
+  ).toBe(403);
+});

--- a/frontend/tests/session.test.ts
+++ b/frontend/tests/session.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+vi.mock("server-only", () => ({}));
+import { NextRequest } from "next/server";
+import { login, logout, profile } from "../src/lib/session";
+const token = "private-bearer-token";
+function request(
+  body: unknown = { email: "demo@example.test", password: "password" },
+  origin: string | null = "https://shop.test",
+) {
+  return new NextRequest("https://shop.test/api/session/login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(origin ? { Origin: origin } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+function upstream(body: unknown, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+}
+beforeEach(() => {
+  vi.stubEnv("APP_ORIGIN", "https://shop.test");
+  upstream({ access_token: token, token_type: "bearer", expires_in: 1800 });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+describe("browser session boundary", () => {
+  it("keeps tokens only in host-only secure HttpOnly cookies", async () => {
+    const res = await login(request());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ authenticated: true });
+    const cookie = res.cookies.get("__Host-session")!;
+    expect(cookie.value).toBe(token);
+    expect(cookie).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+    });
+    expect(cookie.domain).toBeUndefined();
+    expect(cookie.maxAge).toBeLessThan(1800);
+    expect(res.headers.get("cache-control")).toContain("no-store");
+    const call = vi.mocked(fetch).mock.calls[0][0] as Request;
+    expect(call.redirect).toBe("error");
+    expect(call.headers.get("content-type")).toContain(
+      "application/x-www-form-urlencoded",
+    );
+    expect(await call.text()).toContain("username=demo%40example.test");
+  });
+  it.each([null, "https://evil.test", "null"])(
+    "rejects origin %s before upstream access",
+    async (origin) => {
+      expect((await login(request(undefined, origin))).status).toBe(403);
+      expect((await logout(request(undefined, origin))).status).toBe(403);
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+  it.each(["https://evil.test", "//evil.test", "/account", "\\evil"])(
+    "rejects all supplied redirect destinations: %s",
+    async (next) => {
+      expect(
+        (await login(request({ email: "a", password: "b", next }))).status,
+      ).toBe(400);
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+  it("clears invalid credentials but preserves a session on upstream failures", async () => {
+    upstream({ detail: "invalid" }, 401);
+    expect((await login(request())).cookies.get("__Host-session")?.maxAge).toBe(
+      0,
+    );
+    upstream({ detail: "unavailable" }, 500);
+    const failed = await login(request());
+    expect(failed.status).toBe(503);
+    expect(failed.headers.get("set-cookie")).toBeNull();
+  });
+  it("returns only the profile and forwards the bearer server-side", async () => {
+    upstream({
+      id: 1,
+      email: "demo@example.test",
+      is_active: true,
+      is_admin: false,
+    });
+    const res = await profile(
+      new NextRequest("https://shop.test/api/session/me", {
+        headers: { cookie: `__Host-session=${token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(await res.json())).not.toContain(token);
+    expect(
+      (vi.mocked(fetch).mock.calls[0][0] as Request).headers.get(
+        "authorization",
+      ),
+    ).toBe(`Bearer ${token}`);
+    expect(res.headers.get("cache-control")).toContain("no-store");
+  });
+  it("handles missing, expired, malformed and disabled-user sessions as unauthorized", async () => {
+    expect(
+      (await profile(new NextRequest("https://shop.test/api/session/me")))
+        .status,
+    ).toBe(401);
+    expect(fetch).not.toHaveBeenCalled();
+    for (const invalid of ["expired", "malformed", "disabled-user"]) {
+      upstream({ detail: "invalid" }, 401);
+      const res = await profile(
+        new NextRequest("https://shop.test/api/session/me", {
+          headers: { cookie: `__Host-session=${invalid}` },
+        }),
+      );
+      expect(res.status).toBe(401);
+      expect(res.cookies.get("__Host-session")?.maxAge).toBe(0);
+    }
+  });
+  it("deletes the same cookie on logout", async () => {
+    const res = await logout(request());
+    expect(res.cookies.get("__Host-session")).toMatchObject({
+      maxAge: 0,
+      path: "/",
+      secure: true,
+      httpOnly: true,
+    });
+  });
+  it("bounds upstream requests and hides timeout details", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("secret", "TimeoutError")),
+    );
+    const res = await login(request());
+    expect(res.status).toBe(503);
+    expect(await res.text()).not.toContain("secret");
+    expect(vi.mocked(fetch).mock.calls[0][1]?.signal).toBeInstanceOf(
+      AbortSignal,
+    );
+    const p = await profile(
+      new NextRequest("https://shop.test/api/session/me", {
+        headers: { cookie: "__Host-session=x" },
+      }),
+    );
+    expect(p.status).toBe(503);
+    expect(p.headers.get("set-cookie")).toBeNull();
+  });
+  it("requires explicit local mode and never downgrades non-loopback HTTP", async () => {
+    vi.stubEnv("APP_ORIGIN", "http://127.0.0.1:3000");
+    expect(
+      (await login(request(undefined, "http://127.0.0.1:3000"))).status,
+    ).toBe(503);
+    vi.stubEnv("ALLOW_LOCAL_HTTP_SESSIONS", "true");
+    const res = await login(request(undefined, "http://127.0.0.1:3000"));
+    expect(res.cookies.get("local-session")).toMatchObject({
+      secure: false,
+      httpOnly: true,
+    });
+    vi.stubEnv("APP_ORIGIN", "http://shop.test");
+    expect((await login(request(undefined, "http://shop.test"))).status).toBe(
+      503,
+    );
+  });
+  it.each([0, -1, null, "invalid"])(
+    "does not store invalid lifetime %s",
+    async (expires_in) => {
+      upstream({ access_token: token, token_type: "bearer", expires_in });
+      expect((await login(request())).status).toBe(503);
+    },
+  );
+});
+
+it("rejects malformed requests without contacting FastAPI", async () => {
+  for (const body of [
+    null,
+    {},
+    { email: "", password: "x" },
+    { email: "x", password: "" },
+  ])
+    expect((await login(request(body))).status).toBe(400);
+  expect(
+    (
+      await login(
+        new NextRequest("https://shop.test", {
+          method: "POST",
+          headers: { origin: "https://shop.test" },
+        }),
+      )
+    ).status,
+  ).toBe(415);
+  expect(
+    (
+      await login(
+        new NextRequest("https://shop.test", {
+          method: "POST",
+          headers: {
+            origin: "https://shop.test",
+            "content-type": "application/json",
+          },
+          body: "{",
+        }),
+      )
+    ).status,
+  ).toBe(400);
+  expect(fetch).not.toHaveBeenCalled();
+});
+it("fails closed for absent or non-canonical configuration", async () => {
+  for (const origin of ["", "https://shop.test/", "invalid"]) {
+    vi.stubEnv("APP_ORIGIN", origin);
+    expect((await login(request())).status).toBe(503);
+    expect((await logout(request())).status).toBe(503);
+  }
+});
+it("preserves profile cookies on upstream server errors", async () => {
+  upstream({}, 500);
+  const res = await profile(
+    new NextRequest("https://shop.test", {
+      headers: { cookie: "__Host-session=x" },
+    }),
+  );
+  expect(res.status).toBe(503);
+  expect(res.headers.get("set-cookie")).toBeNull();
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     coverage: {
       provider: "v8",
-      include: ["src/lib/catalog.ts"],
+      include: ["src/lib/catalog.ts", "src/lib/session.ts"],
       reporter: ["text", "lcov"],
       thresholds: { statements: 95, branches: 90, functions: 100, lines: 95 },
     },


### PR DESCRIPTION
## Summary
Add Next.js login, profile and logout handlers backed by the existing FastAPI authentication API. Bearer tokens remain in HttpOnly cookies and server-side requests; mutations require the configured browser origin and responses are never shared-cacheable.

## Issue
Closes #24. Account screens remain separate work in #25–27.

## Before / After
Previously only direct FastAPI bearer authentication existed. Browsers can now POST JSON credentials to `/api/session/login`, GET `/api/session/me`, and POST `/api/session/logout` without reading bearer tokens in JavaScript. No caller-controlled redirect destination is accepted.

## Acceptance criteria
- [x] Login and profile requests use the generated API contract.
- [x] Host-only HttpOnly cookies use SameSite=Lax, path=/, HTTPS Secure and bounded lifetime.
- [x] Missing/mismatched origins and redirect parameters are rejected.
- [x] Invalid sessions clear cookies; outages preserve them and return 503.
- [x] Logout, cookie secrecy and the real API session journey are tested.
- [x] Session design, environment examples, roadmap and agent guidance updated.

## Testing
- Backend `make check`: Ruff and all 79 tests passed (using a writable uv cache).
- Frontend lint, typecheck, production build and 25 unit tests passed; session code included in enforced coverage.
- All 7 Playwright tests passed, including the new login/profile/logout journey against a disposable real FastAPI database, catalog desktop/mobile and failure states.
- Local browser checks used temporary isolated ports because 18300 was occupied; original configuration restored. Chromium needed sandbox escalation on macOS.
- OpenAPI and TypeScript contract regenerated; diff whitespace check passed.
- Expired/malformed/disabled-session mapping is tested with mocked upstream 401s; FastAPI already tests underlying token/user validation. No deployed HTTPS browser environment was exercised; secure cookie policy is covered by handler tests.

## Review
- Implementation review: self-review by the implementing agent, including origins, cookie policy, expiry, upstream errors and redirect handling. Upstream redirects explicitly rejected.
- Owner: @youneshenniwrites (assignee).
- External reviewer: Codex Code Review.
- [x] External review completed for the latest commit
- [x] Review findings addressed
- [x] Required CI checks passed
- [x] Current-head external review verified, or explicit owner-approved deferral linked

## Deployment / Compatibility
FastAPI login adds `expires_in`; deploy the updated API before session handlers. Set APP_ORIGIN to the exact HTTPS application origin. Local HTTP requires a loopback origin and explicit ALLOW_LOCAL_HTTP_SESSIONS=true. No schema migration or new dependency. Logout removes the browser cookie but does not revoke copied JWTs; no refresh-token flow is introduced.

Current-head external review: Codex bot ID 199175422 completed review of 5557243eb8fff63d9c228d229c2db50e0533f432 with no major issues. Both previous documentation findings were fixed, replied to and resolved; CI passed on this head.
