### PR TITLE
fix(db): recover pooled connections after hosted PostgreSQL idles

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -8,7 +8,14 @@ from app.core.settings import settings
 # postgres://username:password@localhost:5432/dbname
 SQLALCHEMY_DATABASE_URL = settings.DATABASE_URL
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL, echo=False, future=True)
+
+def create_db_engine(database_url: str):
+    # Hosted PostgreSQL may close idle connections when compute suspends.
+    # Validate at checkout; do not replay transactions or mutations on failure.
+    return create_engine(database_url, echo=False, future=True, pool_pre_ping=True)
+
+
+engine = create_db_engine(SQLALCHEMY_DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/backend/app/tests/test_connection_recovery.py
+++ b/backend/app/tests/test_connection_recovery.py
@@ -1,0 +1,31 @@
+import os
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+from app.db.session import create_db_engine
+
+
+def test_replaces_connection_closed_while_idle():
+    url = os.environ.get("TEST_DATABASE_URL", "")
+    if not url.startswith("postgresql"):
+        pytest.skip("Requires disposable PostgreSQL TEST_DATABASE_URL")
+
+    engine = create_db_engine(url)
+    control = create_engine(url, poolclass=NullPool)
+    try:
+        with engine.connect() as connection:
+            old_pid = connection.scalar(text("SELECT pg_backend_pid()"))
+        # Only terminate the connection this test opened, after returning it
+        # to the pool. This models suspended hosting, without restarting a DB.
+        with control.connect() as connection:
+            assert connection.scalar(
+                text("SELECT pg_terminate_backend(:pid)"), {"pid": old_pid}
+            )
+        with engine.connect() as connection:
+            assert connection.scalar(text("SELECT 1")) == 1
+            assert connection.scalar(text("SELECT pg_backend_pid()")) != old_pid
+    finally:
+        engine.dispose()
+        control.dispose()

--- a/deploy/environments/README.md
+++ b/deploy/environments/README.md
@@ -104,7 +104,11 @@ a backup guarantee; document a tested recovery procedure before relying on one.
 
 Vercel Functions are request-scoped serverless processes, not persistent containers.
 No local persistent writes or durable background jobs are assumed. Neon can suspend
-compute; retain bounded request timeouts and test recovery. The existing five-second
+compute. SQLAlchemy validates pooled connections at checkout (`pool_pre_ping`)
+and replaces those closed while idle. PostgreSQL CI exercises this by terminating
+only a test-owned idle connection and verifying the next checkout succeeds. This
+does not replay interrupted transactions or retry mutations. Retain bounded
+request timeouts and verify hosting recovery. The existing five-second
 frontend timeout may show retry/temporary 503 while services initialize. Do not
 retry login or other mutations automatically. Deployment smoke checks may retry
 bounded read-only requests. Future carts/checkout must keep state and transactions


### PR DESCRIPTION
## Summary
Prevent the first database request after idle from failing when hosted PostgreSQL has closed a pooled connection. Check connection health at checkout and replace disconnected connections before executing application queries.

## Issue
Refs #45. Production delivery remains #46.

## Before / After
| Before | After |
| --- | --- |
| First catalog request after Neon idle shutdown returned HTTP 500; later requests recovered | Dead idle connections are detected and replaced before use |

## Acceptance criteria
- [x] Handle disconnected idle pooled connections.
- [x] Reproduce the failure against disposable PostgreSQL and verify recovery.
- [x] Preserve transaction semantics: no automatic replay of writes or interrupted transactions.
- [x] Document the recovery behavior and limits.

## Testing
- `make check`: lint/format passed; 79 tests passed, PostgreSQL-only regression skipped in SQLite run.
- New regression passed against a separate disposable PostgreSQL 17 container.
- Disabling pre-ping reproduced the same AdminShutdown failure; restored fix passes.
- Hosted development logs confirmed `psycopg.errors.AdminShutdown` following an idle period.
- `git diff --check` passed.
- All applicable CI passed. Codex completed a clean review of dd19beae2b. Hosted redeployment verification follows merge.

## Review
- Implementation review: self-review of engine construction, existing session callers, test isolation and transaction behavior.
- Owner: @youneshenniwrites
- External reviewer: Codex Code Review
- [x] External review completed for the latest commit
- [x] Review findings addressed: no findings yet
- [x] Required CI checks passed
- [x] Current-head external review verified

## Deployment / Compatibility
No schema or API contract change. Pre-ping adds a connection-health check at checkout. Database unavailability or disconnects during a transaction can still fail; writes are not retried. Redeploy both hosted APIs after review. Development previews and automatic production CD remain in #45–46.
