### PR TITLE
fix(ci): pass the matching Vercel project for each deployment

### DIFF
--- a/scripts/deploy_production.py
+++ b/scripts/deploy_production.py
@@ -69,6 +69,7 @@ def main():
                     os.environ["VERCEL_TOKEN"],
                 ],
                 check=True,
+                env={**os.environ, "VERCEL_PROJECT_ID": os.environ[variable]},
             )
             if component == "API":
                 read(API + "/health", retry=True)

--- a/scripts/test_production_ready.py
+++ b/scripts/test_production_ready.py
@@ -1,9 +1,11 @@
 import io
+import json
 import os
 import tarfile
 import tempfile
 import unittest
 import urllib.error
+from pathlib import Path
 from unittest.mock import patch
 
 import deploy_production
@@ -107,6 +109,60 @@ class DeploymentFailureTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "API unavailable"):
                 deploy_production.main()
             self.assertEqual(deploy.call_count, 1)
+
+    def test_cli_receives_matching_org_and_project_for_each_component(self):
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w"):
+            pass
+        selected = []
+
+        def cli(args, check, env=None):
+            env = os.environ if env is None else env
+            # Vercel rejects an exported org without its paired project, even
+            # when the archive includes a valid .vercel/project.json file.
+            self.assertEqual(env["VERCEL_ORG_ID"], "team-test")
+            project = env["VERCEL_PROJECT_ID"]
+            root = Path(args[args.index("--cwd") + 1])
+            self.assertEqual(
+                json.loads((root / ".vercel/project.json").read_text())["projectId"],
+                project,
+            )
+            selected.append(project)
+
+        def read(url, **kwargs):
+            if url.endswith("/api/v1/products/"):
+                return b'[{"name":"Demo product"}]'
+            return b"FORME Demo product"
+
+        with tempfile.NamedTemporaryFile() as summary:
+            env = {
+                "RELEASE_SHA": SHA,
+                "VERCEL_ORG_ID": "team-test",
+                "VERCEL_API_PROJECT_ID": "api-test",
+                "VERCEL_FRONTEND_PROJECT_ID": "frontend-test",
+                "VERCEL_PROJECT_ID": "stale-inherited-project",
+                "VERCEL_TOKEN": "test-placeholder",
+                "GITHUB_STEP_SUMMARY": summary.name,
+            }
+            with (
+                patch.dict(os.environ, env),
+                patch.object(
+                    deploy_production.subprocess,
+                    "check_output",
+                    return_value=archive.getvalue(),
+                ),
+                patch.object(deploy_production.subprocess, "run", side_effect=cli),
+                patch.object(deploy_production, "read", side_effect=read),
+                patch.object(
+                    deploy_production.urllib.request,
+                    "urlopen",
+                    side_effect=urllib.error.HTTPError(
+                        "https://example.com", 403, "Forbidden", {}, None
+                    ),
+                ),
+            ):
+                deploy_production.main()
+        self.assertEqual(selected, ["api-test", "frontend-test"])
 
     def test_read_only_retry_is_bounded(self):
         failure = urllib.error.URLError("unavailable")


### PR DESCRIPTION
## Summary
Fix the first GitHub deployment failure: Vercel rejects an exported VERCEL_ORG_ID without VERCEL_PROJECT_ID, even when the archive has a project file. Pass the matching project ID to each CLI invocation, switching from API to frontend explicitly.

## Issue
Refs #46. Follow-up to merged #49; first release run: https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34261830925

## Before / After
| Before | After |
| --- | --- |
| CI exports the organization but no paired project; Vercel exits before deployment | Each CLI process receives the correct organization/project pair |
| A globally inherited project could select the wrong component | Component-specific selection overrides stale inherited project IDs |

## Acceptance criteria
- [x] Pass the API project to API deployment and frontend project to frontend deployment.
- [x] Preserve matching project-file configuration and environment isolation.
- [x] Regression proves both components receive the correct pair and stale inherited IDs are overridden.
- [x] Successful GitHub release verified; #46 closed.

## Testing
- Seven delivery tests pass, including the new full API/frontend selection path.
- Removing the fix fails the new regression; restored fix passes.
- Ruff lint and git diff --check pass.
- The failed hosted run passed exact-main verification, tool setup and forward migrations; Vercel exited before deployment. Existing production remains live.

## Review
- Implementation review: self-review of per-process environment overrides and both component selections.
- Owner: @youneshenniwrites
- External reviewer: Codex Code Review
- [x] External review completed for the latest commit
- [x] Review findings addressed
- [x] Required CI checks passed
- [x] Current-head external review verified

## Deployment / Compatibility
No application, schema, credential or provider-resource change. Reuse the existing main-only production environment and reviewed delivery workflow. No bypass or manual production source change.

## Delivered evidence
[Production run 34262932296](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34262932296) succeeded for main 88c4ae4, including migrations, both deployments and public smoke checks. #49 and #50 together complete #46.
