### PR TITLE
fix(api): redirect API domain roots to Swagger

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ import logging
 import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
 
 from app.api.v1 import auth, products
 
@@ -57,6 +58,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.get("/", include_in_schema=False)
+async def documentation_home() -> RedirectResponse:
+    """Make dashboard domain links open the API's interactive documentation."""
+    return RedirectResponse(url="/docs", status_code=307)
 
 
 # --------------------------

--- a/backend/app/tests/test_openapi.py
+++ b/backend/app/tests/test_openapi.py
@@ -14,3 +14,15 @@ def test_openapi_documents_security_errors_and_money(client):
     )
     assert client.get("/docs").status_code == 200
     assert client.get("/redoc").status_code == 200
+
+
+def test_api_domain_opens_swagger_without_changing_contract(client):
+    for path in ("/", "/?next=https://untrusted.example"):
+        response = client.get(path, follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "/docs"
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "swagger-ui" in response.text
+    assert "/" not in client.get("/openapi.json").json()["paths"]
+    assert client.get("/health").json() == {"status": "ok"}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,9 @@
 # API contract and interactive documentation
 
+Opening the API domain root `/` redirects to `/docs` (Swagger UI), including
+Vercel dashboard domain links. This is the API documentation entry point; the
+storefront is a separate frontend domain. The redirect is not an OpenAPI operation.
+
 FastAPI publishes an OpenAPI 3.1 contract for every implemented endpoint:
 
 - Swagger UI: http://localhost:8000/docs

--- a/scripts/deploy_production.py
+++ b/scripts/deploy_production.py
@@ -75,6 +75,7 @@ def main():
                 read(API + "/health", retry=True)
                 products = json.loads(read(API + "/api/v1/products/", retry=True))
                 assert isinstance(products, list) and products, "Demo catalog is empty"
+                read(API + "/")  # Dashboard domain link must resolve to docs.
                 read(API + "/docs")
                 read(API + "/openapi.json")
                 read(API + "/api/v1/auth/me", expected=401)


### PR DESCRIPTION
## Summary
Opening a Vercel API domain now redirects to Swagger UI through a fixed, relative `/docs` redirect. Add regression coverage, a production smoke check and onboarding guidance.

## Issue
Closes #51. Both hosted environments verified after merge.

## Before / After
| Before | After |
| --- | --- |
| API domain root returns JSON 404 | GET `/` returns 307 to `/docs` and opens Swagger |

## Acceptance criteria
- [x] Fixed relative redirect ignores query parameters
- [x] Existing health behavior and OpenAPI contract preserved
- [x] Regression tests, release smoke check and documentation updated
- [x] Both hosted API domains verified after merge

## Testing
- `make check`: lint and formatting passed; 80 tests passed, 1 PostgreSQL-only test skipped locally.
- Delivery unit tests: 7 passed.
- `git diff --check`: passed.
- PostgreSQL/container integration checks run in CI; hosted verification follows deployment.

## Review
- Implementation review: self-review of the complete diff
- Owner: @youneshenniwrites
- External reviewer: Codex Code Review
- [x] External review completed for `cca930b38b262b7ea6382731f2f40e5e861cb5f3` ([clean result](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/52#issuecomment-5590060595))
- [x] No review findings or unresolved threads
- [x] Required CI checks passed, including PostgreSQL integration, container and browser tests

## Deployment / Compatibility
No migrations or configuration changes. Root is excluded from OpenAPI; existing API endpoints retain their paths. Production deploys through GitHub Actions; development API is deployed from the reviewed merged commit. Reverting restores the previous root 404.


Delivery verified on `d005a4ad78288a1f8bd27b760a52c0a5548b5101`: [production workflow](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34264764225) passed. Both API roots return 307 to `/docs`, followed by Swagger 200; health, OpenAPI, catalog and both storefronts pass. Wiki onboarding updated.
