### PR TITLE
feat(hosting): support trusted VINDOR domain aliases

### DIFF
--- a/deploy/environments/README.md
+++ b/deploy/environments/README.md
@@ -150,7 +150,28 @@ eligible main release will advance production again.
 
 ## VINDOR identity
 
-VINDOR is the public product name (formerly FORME). Existing repository slug,
-Vercel project IDs, deployment domains and database/role identifiers remain stable
-to preserve CI, links and sessions. They are infrastructure identifiers, not
-storefront branding. No data migration or paid domain is needed for this rename.
+VINDOR is the public product name (formerly FORME). Vercel and Neon project display names use VINDOR.
+Repository slug, project IDs, database names/roles and credentials remain stable.
+The original FORME domains remain available during the migration. No database
+migration or paid domain is needed. See the environment rollout below for URLs.
+
+## VINDOR domain rollout
+
+The free API aliases are `https://vindor-api-production.vercel.app` and
+`https://vindor-api-development.vercel.app`; `/docs` opens Swagger UI.
+The storefront aliases to activate after this change deploys are
+`https://vindor-ecommerce.vercel.app` and
+`https://vindor-ecommerce-development.vercel.app`.
+
+Keep each environment's existing `APP_ORIGIN` and set `APP_ORIGIN_ALIASES` to a
+JSON array containing only its new storefront origin. No wildcard or automatic
+trust of request hosts is allowed. Aliases must be exact HTTPS origins, with at
+most five entries; malformed configuration fails closed. Local HTTP sessions do
+not support aliases. Both old and new origins then pass the same session checks.
+Host-only cookies remain isolated: users sign in separately on each hostname.
+Do not mix development and production origins.
+
+Deploy the reviewed change before assigning storefront aliases to the current
+production target in each Vercel project. Verify both domains, `/api/session/me`,
+valid-origin logout, rejected untrusted-origin logout and image loading. Existing
+API_BASE_URL and delivery smoke URLs remain valid through retained FORME aliases.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ The legacy AWS Terraform is not used for this deployment.
 
 ## VINDOR identity
 
-VINDOR is the public product name (formerly FORME). Existing repository slug,
-Vercel project IDs, deployment domains and database/role identifiers remain stable
-to preserve CI, links and sessions. They are infrastructure identifiers, not
-storefront branding. No data migration or paid domain is needed for this rename.
+VINDOR is the public product name (formerly FORME). Vercel and Neon project display names use VINDOR.
+Repository slug, project IDs, database names/roles and credentials remain stable.
+Original FORME domains remain available during migration; see the
+[environment rollout](../deploy/environments/README.md#vindor-domain-rollout).

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,6 @@ API_BASE_URL=http://127.0.0.1:8000
 APP_ORIGIN=http://127.0.0.1:3000
 # Local loopback HTTP only; omit on hosted deployments.
 ALLOW_LOCAL_HTTP_SESSIONS=true
+
+# Optional exact HTTPS aliases on hosted deployments, JSON array; never wildcards.
+APP_ORIGIN_ALIASES=[]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -72,7 +72,9 @@ set APP_ORIGIN to their public origin and omit ALLOW_LOCAL_HTTP_SESSIONS.
 
 POST /api/session/login accepts JSON email/password; GET /api/session/me returns
 the active profile; POST /api/session/logout clears the HttpOnly cookie. Browser
-mutations require the configured Origin. All responses are private/no-store,
+mutations require the configured APP_ORIGIN or an explicitly configured HTTPS
+APP_ORIGIN_ALIASES entry (JSON array, at most five). Host-only cookies are not
+shared between aliases. Invalid alias configuration fails closed. All responses are private/no-store,
 return no bearer token in JSON and use bounded upstream requests. See
 [session design](../docs/design/customer-sessions.md) for errors, expiry and
 stateless logout limitations. Account forms are the next feature tickets.

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -20,8 +20,19 @@ function policy() {
     throw new Error(
       "Sessions require HTTPS or explicit loopback development mode",
     );
+  const aliases: unknown = JSON.parse(process.env.APP_ORIGIN_ALIASES || "[]");
+  if (!Array.isArray(aliases) || aliases.length > 5)
+    throw new Error(
+      "APP_ORIGIN_ALIASES must be an array of at most five origins",
+    );
+  for (const alias of aliases) {
+    if (typeof alias !== "string") throw new Error("Invalid origin alias");
+    const parsed = new URL(alias);
+    if (!secure || parsed.protocol !== "https:" || parsed.origin !== alias)
+      throw new Error("Origin aliases must be exact HTTPS origins");
+  }
   return {
-    origin: raw,
+    origins: [raw, ...aliases],
     secure,
     name: secure ? "__Host-session" : "local-session",
   };
@@ -51,7 +62,7 @@ function clear(response: NextResponse, config: ReturnType<typeof policy>) {
 export async function login(request: NextRequest) {
   try {
     const config = policy();
-    if (request.headers.get("origin") !== config.origin)
+    if (!config.origins.includes(request.headers.get("origin") ?? ""))
       return reply({ error: "Origin rejected" }, 403);
     if (!request.headers.get("content-type")?.startsWith("application/json"))
       return reply({ error: "Expected JSON" }, 415);
@@ -131,7 +142,7 @@ export async function profile(request: NextRequest) {
 export async function logout(request: NextRequest) {
   try {
     const config = policy();
-    if (request.headers.get("origin") !== config.origin)
+    if (!config.origins.includes(request.headers.get("origin") ?? ""))
       return reply({ error: "Origin rejected" }, 403);
     return clear(reply({ authenticated: false }), config);
   } catch {

--- a/frontend/tests/session.test.ts
+++ b/frontend/tests/session.test.ts
@@ -29,6 +29,7 @@ function upstream(body: unknown, status = 200) {
 }
 beforeEach(() => {
   vi.stubEnv("APP_ORIGIN", "https://shop.test");
+  vi.stubEnv("APP_ORIGIN_ALIASES", "");
   upstream({ access_token: token, token_type: "bearer", expires_in: 1800 });
 });
 afterEach(() => {
@@ -226,4 +227,48 @@ it("preserves profile cookies on upstream server errors", async () => {
   );
   expect(res.status).toBe(503);
   expect(res.headers.get("set-cookie")).toBeNull();
+});
+
+it("accepts only explicitly configured HTTPS migration aliases", async () => {
+  vi.stubEnv("APP_ORIGIN_ALIASES", '["https://new-shop.test"]');
+  expect(
+    (await login(request(undefined, "https://new-shop.test"))).status,
+  ).toBe(200);
+  expect(
+    (await logout(request(undefined, "https://new-shop.test"))).status,
+  ).toBe(200);
+  upstream({ access_token: token, token_type: "bearer", expires_in: 1800 });
+  expect((await login(request())).status).toBe(200);
+  vi.mocked(fetch).mockClear();
+  for (const origin of [
+    "https://new-shop.test.evil.test",
+    "https://other.test",
+    null,
+  ]) {
+    expect((await login(request(undefined, origin))).status).toBe(403);
+    expect((await logout(request(undefined, origin))).status).toBe(403);
+  }
+  expect(fetch).not.toHaveBeenCalled();
+});
+it.each([
+  "invalid",
+  "null",
+  '"https://new-shop.test"',
+  "[42]",
+  '["https://user:pass@shop.test"]',
+  '["https://shop.test/path"]',
+  '["http://shop.test"]',
+  '["invalid"]',
+  JSON.stringify(Array(6).fill("https://shop.test")),
+])("fails closed for invalid aliases: %s", async (aliases) => {
+  vi.stubEnv("APP_ORIGIN_ALIASES", aliases);
+  expect((await login(request())).status).toBe(503);
+  expect((await logout(request())).status).toBe(503);
+  expect(fetch).not.toHaveBeenCalled();
+});
+it("rejects aliases in local HTTP mode", async () => {
+  vi.stubEnv("APP_ORIGIN", "http://127.0.0.1:3000");
+  vi.stubEnv("ALLOW_LOCAL_HTTP_SESSIONS", "true");
+  vi.stubEnv("APP_ORIGIN_ALIASES", '["https://new-shop.test"]');
+  expect((await login(request())).status).toBe(503);
 });


### PR DESCRIPTION
## Summary
Support explicitly configured HTTPS storefront aliases so VINDOR and existing FORME domains can share the deployment without disabling origin checks. Rename provider display names and document the compatible domain rollout; database identifiers stay stable.

## Issue
Refs #58. Close the ticket after hosted aliases and both environments are verified.

## Before / After
Previously session mutations accepted one APP_ORIGIN. They now also accept up to five exact HTTPS origins from APP_ORIGIN_ALIASES; missing aliases preserve existing behavior. Invalid configuration fails closed. Cookies remain host-only and users sign in separately per hostname.

## Acceptance criteria
- [x] Explicit HTTPS alias validation, no wildcard or inferred host trust.
- [x] Original origin still accepted; untrusted and malformed aliases rejected.
- [x] Environment examples and architecture guidance updated.
- [ ] Hosted storefront aliases activated and smoke-tested after deployment.

## Testing
36 unit tests passed, with 100% coverage of configured catalog/session modules. ESLint, TypeScript and git diff --check passed. Regression coverage includes both accepted origins, lookalike attackers, invalid arrays/URLs, credentials, HTTP and local-mode rejection. Build/browser tests run in CI.

## Review
Implementation review: self-review of origin parsing, rejection paths, cookie isolation and deployment configuration. Owner: @youneshenniwrites. External reviewer: Codex Code Review; pending.

## Deployment / Compatibility
Set each frontend project's APP_ORIGIN_ALIASES to its own new HTTPS hostname before deploying. Keep APP_ORIGIN and existing domains unchanged. Activate new aliases only after reviewed code deploys. Vercel/Neon display names and API aliases are already updated; no database/schema/credential changes or paid domains.
