### PR TITLE
feat(auth): add customer profile and account navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Working in this repository
 
 The product has a FastAPI backend and a runnable Next.js catalog storefront.
-Server-mediated customer sessions and registration/login screens are implemented;
-profile/navigation and checkout are planned. Read
+Server-mediated customer sessions, registration/login screens and profile/navigation
+are implemented; checkout is planned. Read
 docs/plans/portfolio.md, docs/architecture.md, and docs/plans/roadmap.md before choosing work; update their
 factual status when a feature lands.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The backend and catalog storefront run locally and in a
 
 | Area | Status |
 | --- | --- |
-| Accounts | Registration/login screens, HttpOnly browser sessions, current-user API, disabled-user rejection |
+| Accounts | Registration/login screens, HttpOnly browser sessions, private profile page, sign-out, disabled-user rejection |
 | Product catalog | Public reads; creation, partial updates, deletion restricted to active admins |
 | Money and validation | Fixed-precision GBP prices, database constraints, bounded pagination |
 | Persistence | PostgreSQL, Alembic migrations, legacy-data validation |
@@ -223,8 +223,8 @@ Azure is an optional future migration (#31). The AWS Terraform in backend/infra
 remains legacy reference. No paid upgrade or new AI API billing is authorized.
 
 This is a [senior SWE portfolio project](docs/plans/portfolio.md).
-The next product steps are profile/account navigation (#26), account journey
-verification (#27), carts, orders, and sandbox payments. Follow the
+The next product steps are account journey verification (#27), carts, orders,
+and sandbox payments. Follow the
 [ordered roadmap](docs/plans/roadmap.md) for the remaining work.
 
 ## Try customer accounts
@@ -232,8 +232,9 @@ verification (#27), carts, orders, and sandbox payments. Follow the
 Use the hosted [registration page](https://vindor-ecommerce.vercel.app/register)
 and [sign-in page](https://vindor-ecommerce.vercel.app/login) with fictional demo
 details and a password you do not use elsewhere. Registration does not sign you
-in automatically. Successful login returns to the catalog; a profile page and
-signed-in navigation are planned in #26. Session tokens stay in HttpOnly cookies.
+in automatically. Successful login returns to the catalog; choose My account in
+the navigation to view your profile and sign out. The [account page](https://vindor-ecommerce.vercel.app/account)
+requires a valid session. Session tokens stay in HttpOnly cookies.
 See the [session design](docs/design/customer-sessions.md) for implemented
 handlers, security boundaries and remaining work.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,9 @@ profile. No public route creates an admin.
 The Next.js registration and login screens call same-origin session handlers.
 Login stores the API token in an HttpOnly cookie; server-mediated profile calls
 forward it to FastAPI. Session responses are private and not cached. Registration
-does not automatically sign in. Profile/account navigation remains planned (#26);
+does not automatically sign in. The account page fetches the current profile
+through the private handler; its shared page HTML contains only a public shell.
+Navigation reflects the verified session, and sign-out clears the cookie;
 see the [session design](design/customer-sessions.md).
 
 CI performs locked dependency installation, lint, formatting, tests, and a real

--- a/docs/design/customer-sessions.md
+++ b/docs/design/customer-sessions.md
@@ -1,7 +1,7 @@
 # Customer sessions — issue #24
 
-Session handlers and registration/login screens are implemented; profile/navigation
-and broader journey verification remain in #26–27.
+Session handlers, registration/login screens and profile/navigation are implemented.
+Broader journey verification remains in #27.
 
 - POST `/api/session/register`: JSON email/password, returns registered: true (201);
   duplicate registration returns a generic 400, validation 422 and upstream failure
@@ -78,3 +78,21 @@ silently authenticate. An uncertain response advises trying sign-in before
 registering again. Login always navigates to `/#collection`, ignoring query-string
 redirect destinations. Credentials are not persisted in browser storage or traces.
 Password reset, email verification and rate limiting remain separate work.
+
+
+## Profile and navigation (#26)
+
+`/account` renders a public loading shell and retrieves only the current customer
+through GET `/api/session/me`. No profile data or bearer token is included in
+shared page HTML. The private endpoint remains no-store; UI state is held only
+in memory. The account page displays email and membership date, never admin flags.
+A missing/expired session shows a sign-in prompt; an outage hides details and
+shows a retry action without claiming the customer is signed out.
+
+Desktop and mobile navigation use the same session state. It is revalidated on
+route changes, page restoration, focus/visibility changes, and every minute while
+visible. Hidden/leaving pages clear their profile snapshot; aborted or superseded
+requests cannot restore it. The sign-out button posts to the origin-checked
+logout handler and then performs a full navigation to `/login` to discard the
+router cache. Failed sign-out shows an error and allows retry; it never claims
+success. Clearing a browser cookie still does not revoke copied JWTs.

--- a/docs/design/customer-sessions.md
+++ b/docs/design/customer-sessions.md
@@ -89,9 +89,11 @@ in memory. The account page displays email and membership date, never admin flag
 A missing/expired session shows a sign-in prompt; an outage hides details and
 shows a retry action without claiming the customer is signed out.
 
-Desktop and mobile navigation use the same session state. It is revalidated on
-route changes, page restoration, focus/visibility changes, and every minute while
-visible. Hidden/leaving pages clear their profile snapshot; aborted or superseded
+Desktop and mobile navigation share a session lookup. The account page uses its
+own lookup boundary so session updates do not wrap streamed catalog content. It is revalidated on
+mount, page restoration, focus/visibility changes, and every minute while visible.
+Account links and successful sign-in use full navigations to prevent cached
+private screens from being restored by the client router. Hidden/leaving pages clear their profile snapshot; aborted or superseded
 requests cannot restore it. The sign-out button posts to the origin-checked
 logout handler and then performs a full navigation to `/login` to discard the
 router cache. Failed sign-out shows an error and allows retry; it never claims

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -22,6 +22,7 @@ Purpose and priorities: [senior SWE portfolio plan](portfolio.md).
 
 - Explicit admin bootstrap and empty-catalog demo seeding; see [demo guide](../demo.md).
 - Next.js catalog/detail storefront, generated API contract, state handling and desktop/mobile browser checks.
+- Private profile page, session-aware desktop/mobile navigation and sign-out (#26).
 - Registration/login screens with same-origin registration and fixed safe navigation (#25).
 - Server-mediated login/profile/logout with HttpOnly cookies and exact origin checks (#24 / #41).
 - Isolated Vercel/Neon development and production configuration (#44 / #47).
@@ -37,7 +38,7 @@ account, cart and checkout components are added with their feature tickets.
 ## Next PRs, in dependency order
 
 1. Finish frontend PR previews with safe development data and exact origins (#45).
-2. Profile/account navigation and full journey verification (#26–27).
+2. Full account journey verification (#27).
    Keep authorization in FastAPI.
 3. Persistent carts: ownership, quantity changes/removal, stock checks, API and UI.
 4. Orders and checkout: price snapshots, authoritative totals, atomic inventory
@@ -69,4 +70,4 @@ broader items into focused PR tickets before implementation. See
 
 Hosting setup #44 and production workflow acceptance #46 are complete.
 Development and production are live; #45 tracks the remaining frontend previews.
-Profile/account navigation (#26) is the next product task. Azure is deferred; no extra API billing is allowed.
+Account journey verification (#27) is the next product task. Azure is deferred; no extra API billing is allowed.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -21,7 +21,7 @@ Verify keyboard access, mobile layout and automated accessibility checks. Produc
 photography is licensed and stored locally; unknown names use a Lucide placeholder.
 Read PHOTO_CREDITS.md before replacing assets. Never create custom SVG artwork.
 
-Server-mediated sessions and registration/login screens are implemented; profile/navigation, cart and checkout remain planned. Development and production demos are deployed.
+Server-mediated sessions, registration/login screens and profile/navigation are implemented; cart and checkout remain planned. Development and production demos are deployed.
 Read deploy/environments/README.md in the repository root for the approved hosting plan. Do not
 present working purchase controls until the corresponding transaction exists.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -79,8 +79,8 @@ return no bearer token in JSON and use bounded upstream requests. See
 [session design](../docs/design/customer-sessions.md) for errors, expiry and
 stateless logout limitations. Visit `/register` to create a demo account and
 `/login` to sign in. Registration uses the same-origin `/api/session/register`
-handler; a successful login always returns to the collection. Profile/navigation
-and broader journey verification remain #26–27.
+handler; a successful login always returns to the collection. Profile/navigation is implemented in `/account`; broader journey verification
+remains #27.
 
 ## UI components
 

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -1,0 +1,8 @@
+import { AccountProfile } from "@/components/account-profile";
+export const metadata = {
+  title: "My account",
+  robots: { index: false, follow: false },
+};
+export default function Page() {
+  return <AccountProfile />;
+}

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -1,8 +1,13 @@
+import { SessionProvider } from "@/components/session-provider";
 import { AccountProfile } from "@/components/account-profile";
 export const metadata = {
   title: "My account",
   robots: { index: false, follow: false },
 };
 export default function Page() {
-  return <AccountProfile />;
+  return (
+    <SessionProvider>
+      <AccountProfile />
+    </SessionProvider>
+  );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { SiteHeader } from "@/components/site-header";
 import { SiteFooter } from "@/components/site-footer";
 import "./globals.css";
+import { SessionProvider } from "@/components/session-provider";
 export const metadata: Metadata = {
   title: { default: "VINDOR — Room to think", template: "%s | VINDOR" },
   description:
@@ -21,9 +22,11 @@ export default function RootLayout({
         >
           Skip to content
         </a>
-        <SiteHeader />
-        {children}
-        <SiteFooter />
+        <SessionProvider>
+          <SiteHeader />
+          {children}
+          <SiteFooter />
+        </SessionProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -24,9 +24,9 @@ export default function RootLayout({
         </a>
         <SessionProvider>
           <SiteHeader />
-          {children}
-          <SiteFooter />
         </SessionProvider>
+        {children}
+        <SiteFooter />
       </body>
     </html>
   );

--- a/frontend/src/components/account-form.tsx
+++ b/frontend/src/components/account-form.tsx
@@ -2,14 +2,12 @@
 
 import Link from "next/link";
 import { useEffect, useRef, useState, type FormEvent } from "react";
-import { useRouter } from "next/navigation";
 import { ArrowLeft, CheckCircle2, LoaderCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 export function AccountForm({ mode }: { mode: "login" | "register" }) {
   const registering = mode === "register";
-  const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState("");
   const [registered, setRegistered] = useState(false);
@@ -47,8 +45,8 @@ export function AccountForm({ mode }: { mode: "login" | "register" }) {
         form.reset();
         if (registering) setRegistered(true);
         else {
-          router.replace("/#collection");
-          router.refresh();
+          // Discard cached account/navigation state after authentication.
+          window.location.replace("/#collection");
         }
       } else if (!registering && response.status === 401) {
         setError("Email or password is incorrect. Please try again.");

--- a/frontend/src/components/account-link.tsx
+++ b/frontend/src/components/account-link.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Link from "next/link";
 import { useSession } from "@/components/session-provider";
 export function AccountLink({
   className,
@@ -9,14 +8,21 @@ export function AccountLink({
   onClick?: () => void;
 }) {
   const session = useSession();
+  if (session.status === "loading") {
+    return (
+      <span className={className} aria-busy="true">
+        Account
+      </span>
+    );
+  }
   const guest = session.status === "guest";
   return (
-    <Link
+    <a
       href={guest ? "/login" : "/account"}
       className={className}
       onClick={onClick}
     >
       {guest ? "Sign in" : "My account"}
-    </Link>
+    </a>
   );
 }

--- a/frontend/src/components/account-link.tsx
+++ b/frontend/src/components/account-link.tsx
@@ -1,0 +1,22 @@
+"use client";
+import Link from "next/link";
+import { useSession } from "@/components/session-provider";
+export function AccountLink({
+  className,
+  onClick,
+}: {
+  className?: string;
+  onClick?: () => void;
+}) {
+  const session = useSession();
+  const guest = session.status === "guest";
+  return (
+    <Link
+      href={guest ? "/login" : "/account"}
+      className={className}
+      onClick={onClick}
+    >
+      {guest ? "Sign in" : "My account"}
+    </Link>
+  );
+}

--- a/frontend/src/components/account-profile.tsx
+++ b/frontend/src/components/account-profile.tsx
@@ -1,0 +1,108 @@
+"use client";
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { LogOut, UserRound } from "lucide-react";
+import { useSession } from "@/components/session-provider";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+export function AccountProfile() {
+  const session = useSession();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+  const busy = useRef(false);
+  async function signOut() {
+    if (busy.current) return;
+    busy.current = true;
+    setPending(true);
+    setError("");
+    try {
+      const response = await fetch("/api/session/logout", {
+        method: "POST",
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!response.ok || (await response.json()).authenticated !== false)
+        throw new Error();
+      // A full navigation discards in-memory private state and the router cache.
+      window.location.replace("/login");
+    } catch {
+      setError("We couldn't confirm sign-out. Please try again.");
+      setPending(false);
+      busy.current = false;
+    }
+  }
+  return (
+    <main id="main" className="mx-auto w-full max-w-xl px-6 py-12 sm:py-20">
+      <p className="text-xs tracking-widest text-muted-foreground">
+        YOUR VINDOR ACCOUNT
+      </p>
+      <h1 className="mt-3 font-serif text-4xl sm:text-5xl">Your space.</h1>
+      {session.status === "loading" ? (
+        <div role="status" className="mt-8 space-y-4">
+          <span className="sr-only">Loading your account…</span>
+          <Skeleton className="h-8 w-2/3" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : session.status === "guest" ? (
+        <section className="mt-8 space-y-5">
+          <h2 className="text-xl">Sign in to view your account</h2>
+          <p className="text-sm text-muted-foreground">
+            Your session may have expired. Sign in to continue.
+          </p>
+          <Button asChild>
+            <Link href="/login">Sign in</Link>
+          </Button>
+        </section>
+      ) : session.status === "error" ? (
+        <section className="mt-8 space-y-5">
+          <p role="alert">
+            Your account is temporarily unavailable. Please try again.
+          </p>
+          <Button onClick={() => window.location.reload()}>Try again</Button>
+        </section>
+      ) : (
+        <section
+          aria-label="Customer profile"
+          className="mt-8 rounded-lg border border-border p-6 sm:p-8"
+        >
+          <UserRound aria-hidden="true" className="mb-5 size-7 text-primary" />
+          <h2 className="text-xl">Account details</h2>
+          <dl className="mt-6 space-y-5 text-sm">
+            <div>
+              <dt className="text-muted-foreground">Email address</dt>
+              <dd className="mt-1 break-all font-medium">
+                {session.user.email}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Member since</dt>
+              <dd className="mt-1">
+                {new Intl.DateTimeFormat("en-GB", {
+                  dateStyle: "long",
+                  timeZone: "UTC",
+                }).format(new Date(session.user.created_at))}
+              </dd>
+            </div>
+          </dl>
+          <Button onClick={signOut} disabled={pending} className="mt-8">
+            <LogOut aria-hidden="true" />
+            {pending ? "Signing out…" : "Sign out"}
+          </Button>
+          {error && (
+            <p role="alert" className="mt-4 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+        </section>
+      )}
+      <p className="mt-8 text-sm text-muted-foreground">
+        A fictional shop. Browse the collection in GBP.
+      </p>
+      <Link
+        href="/#collection"
+        className="mt-3 inline-block text-sm underline underline-offset-4"
+      >
+        Back to the collection
+      </Link>
+    </main>
+  );
+}

--- a/frontend/src/components/account-profile.tsx
+++ b/frontend/src/components/account-profile.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Link from "next/link";
 import { useRef, useState } from "react";
 import { LogOut, UserRound } from "lucide-react";
 import { useSession } from "@/components/session-provider";
@@ -49,7 +48,7 @@ export function AccountProfile() {
             Your session may have expired. Sign in to continue.
           </p>
           <Button asChild>
-            <Link href="/login">Sign in</Link>
+            <a href="/login">Sign in</a>
           </Button>
         </section>
       ) : session.status === "error" ? (
@@ -97,12 +96,14 @@ export function AccountProfile() {
       <p className="mt-8 text-sm text-muted-foreground">
         A fictional shop. Browse the collection in GBP.
       </p>
-      <Link
+      {/* Full navigation intentionally discards the private account router state. */}
+      {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+      <a
         href="/#collection"
         className="mt-3 inline-block text-sm underline underline-offset-4"
       >
         Back to the collection
-      </Link>
+      </a>
     </main>
   );
 }

--- a/frontend/src/components/mobile-navigation.tsx
+++ b/frontend/src/components/mobile-navigation.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Link from "next/link";
+import { AccountLink } from "@/components/account-link";
 import { useEffect, useState } from "react";
 import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -62,14 +63,10 @@ export function MobileNavigation() {
                 Our approach
               </Link>
             </SheetClose>
-            <SheetClose asChild>
-              <Link
-                className="border-b border-border py-5 text-base"
-                href="/login"
-              >
-                Sign in
-              </Link>
-            </SheetClose>
+            <AccountLink
+              className="border-b border-border py-5 text-base"
+              onClick={() => setOpen(false)}
+            />
           </nav>
           <p className="mt-auto p-6 text-xs text-muted-foreground">
             Fictional shop · Browse in GBP

--- a/frontend/src/components/session-provider.tsx
+++ b/frontend/src/components/session-provider.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname } from "next/navigation";
+import type { components } from "@/lib/api/schema";
+
+type User = Pick<components["schemas"]["UserRead"], "email" | "created_at">;
+type Session =
+  | { status: "loading" }
+  | { status: "guest" }
+  | { status: "error" }
+  | { status: "authenticated"; user: User };
+const SessionContext = createContext<Session>({ status: "loading" });
+export function useSession() {
+  return useContext(SessionContext);
+}
+
+// Only the public shell is rendered on the server. Private data is fetched with
+// cookies through the same-origin handler; never serialize a token into React.
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const [snapshot, setSnapshot] = useState<{
+    path: string;
+    session: Session;
+  }>();
+  useEffect(() => {
+    let controller: AbortController | undefined;
+    let active = true;
+    async function refresh() {
+      controller?.abort();
+      const current = new AbortController();
+      controller = current;
+      setSnapshot({ path: pathname, session: { status: "loading" } });
+      try {
+        const response = await fetch("/api/session/me", {
+          cache: "no-store",
+          signal: AbortSignal.any([current.signal, AbortSignal.timeout(10000)]),
+        });
+        let session: Session;
+        if (response.status === 401) session = { status: "guest" };
+        else if (!response.ok) session = { status: "error" };
+        else {
+          const user: components["schemas"]["UserRead"] = await response.json();
+          session = {
+            status: "authenticated",
+            user: { email: user.email, created_at: user.created_at },
+          };
+        }
+        if (active && !current.signal.aborted)
+          setSnapshot({ path: pathname, session });
+      } catch {
+        if (active && !current.signal.aborted)
+          setSnapshot({ path: pathname, session: { status: "error" } });
+      }
+    }
+    function hide() {
+      controller?.abort();
+      setSnapshot(undefined);
+    }
+    function visibility() {
+      if (document.visibilityState === "visible") void refresh();
+      else hide();
+    }
+    void refresh();
+    const timer = window.setInterval(() => {
+      if (document.visibilityState === "visible") void refresh();
+    }, 60000);
+    window.addEventListener("pageshow", refresh);
+    window.addEventListener("pagehide", hide);
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", visibility);
+    return () => {
+      window.clearInterval(timer);
+      active = false;
+      controller?.abort();
+      window.removeEventListener("pageshow", refresh);
+      window.removeEventListener("pagehide", hide);
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", visibility);
+    };
+  }, [pathname]);
+  const session =
+    snapshot?.path === pathname
+      ? snapshot.session
+      : { status: "loading" as const };
+  return (
+    <SessionContext.Provider value={session}>
+      {children}
+    </SessionContext.Provider>
+  );
+}

--- a/frontend/src/components/session-provider.tsx
+++ b/frontend/src/components/session-provider.tsx
@@ -7,7 +7,6 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { usePathname } from "next/navigation";
 import type { components } from "@/lib/api/schema";
 
 type User = Pick<components["schemas"]["UserRead"], "email" | "created_at">;
@@ -24,19 +23,19 @@ export function useSession() {
 // Only the public shell is rendered on the server. Private data is fetched with
 // cookies through the same-origin handler; never serialize a token into React.
 export function SessionProvider({ children }: { children: ReactNode }) {
-  const pathname = usePathname();
-  const [snapshot, setSnapshot] = useState<{
-    path: string;
-    session: Session;
-  }>();
+  const [snapshot, setSnapshot] = useState<Session>();
   useEffect(() => {
     let controller: AbortController | undefined;
     let active = true;
     async function refresh() {
       controller?.abort();
+      if (document.visibilityState !== "visible") {
+        setSnapshot(undefined);
+        return;
+      }
       const current = new AbortController();
       controller = current;
-      setSnapshot({ path: pathname, session: { status: "loading" } });
+      setSnapshot({ status: "loading" });
       try {
         const response = await fetch("/api/session/me", {
           cache: "no-store",
@@ -52,11 +51,14 @@ export function SessionProvider({ children }: { children: ReactNode }) {
             user: { email: user.email, created_at: user.created_at },
           };
         }
-        if (active && !current.signal.aborted)
-          setSnapshot({ path: pathname, session });
+        if (
+          active &&
+          !current.signal.aborted &&
+          document.visibilityState === "visible"
+        )
+          setSnapshot(session);
       } catch {
-        if (active && !current.signal.aborted)
-          setSnapshot({ path: pathname, session: { status: "error" } });
+        if (active && !current.signal.aborted) setSnapshot({ status: "error" });
       }
     }
     function hide() {
@@ -84,11 +86,8 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       window.removeEventListener("focus", refresh);
       document.removeEventListener("visibilitychange", visibility);
     };
-  }, [pathname]);
-  const session =
-    snapshot?.path === pathname
-      ? snapshot.session
-      : { status: "loading" as const };
+  }, []);
+  const session = snapshot ?? { status: "loading" as const };
   return (
     <SessionContext.Provider value={session}>
       {children}

--- a/frontend/src/components/site-header.tsx
+++ b/frontend/src/components/site-header.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { MobileNavigation } from "@/components/mobile-navigation";
 import { container } from "@/components/storefront-layout";
 import { cn } from "@/lib/utils";
+import { AccountLink } from "@/components/account-link";
 export function Wordmark() {
   return (
     <Link
@@ -49,9 +50,7 @@ export function SiteHeader() {
           >
             Our approach
           </Link>
-          <Link className="hover:underline underline-offset-8" href="/login">
-            Sign in
-          </Link>
+          <AccountLink className="hover:underline underline-offset-8" />
         </nav>
         <span className="hidden text-[9px] tracking-widest text-muted-foreground lg:inline">
           OBJECTS FOR EVERYDAY FOCUS

--- a/frontend/tests/browser/account.spec.ts
+++ b/frontend/tests/browser/account.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { createHmac } from "node:crypto";
 import AxeBuilder from "@axe-core/playwright";
 
 test("accessible registration, duplicate account, invalid login and safe success", async ({
@@ -101,5 +102,150 @@ test("pending submission prevents duplicates and recovers from a service failure
   await page.getByRole("button", { name: "Sign in", exact: true }).click();
   await expect(page.getByRole("main").getByRole("alert")).toContainText(
     "couldn't connect",
+  );
+});
+
+test("private profile, account navigation and logout on desktop and mobile", async ({
+  page,
+  request,
+}) => {
+  const email = `profile-${crypto.randomUUID()}@example.com`;
+  const password = "disposable-profile-password";
+  await page.goto("/account");
+  await expect(
+    page.getByRole("heading", { name: "Sign in to view your account" }),
+  ).toBeVisible();
+  expect(
+    (
+      await request.post("http://127.0.0.1:18300/api/v1/auth/register", {
+        data: { email, password },
+      })
+    ).status(),
+  ).toBe(201);
+  await page.goto("/login");
+  await page.getByLabel("Email address").fill(email);
+  await page.getByLabel("Password", { exact: true }).fill(password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await expect(page).toHaveURL(/\/#collection$/);
+  if (test.info().project.name.includes("Pixel"))
+    await page.getByRole("button", { name: "Open navigation" }).click();
+  await page.getByRole("link", { name: "My account", exact: true }).click();
+  await expect(
+    page.getByRole("region", { name: "Customer profile" }),
+  ).toContainText(email);
+  expect((await new AxeBuilder({ page }).analyze()).violations).toEqual([]);
+  const html = await (await page.request.get("/account")).text();
+  expect(html).not.toContain(email);
+  const me = await page.request.get("/api/session/me");
+  expect(me.headers()["cache-control"]).toContain("no-store");
+  await page.route("**/api/session/logout", (route) =>
+    route.fulfill({ status: 503, body: "{}" }),
+  );
+  await page.getByRole("button", { name: "Sign out", exact: true }).click();
+  await expect(page.getByRole("main").getByRole("alert")).toContainText(
+    "couldn't confirm sign-out",
+  );
+  await expect(page.getByText(email, { exact: true })).toBeVisible();
+  await page.unroute("**/api/session/logout");
+  await page.getByRole("button", { name: "Sign out", exact: true }).click();
+  await expect(page).toHaveURL(/\/login$/);
+  expect((await page.request.get("/api/session/me")).status()).toBe(401);
+  await page.goBack();
+  await expect(page.getByText(email, { exact: true })).toHaveCount(0);
+  await page.goto("/account");
+  await expect(
+    page.getByRole("heading", { name: "Sign in to view your account" }),
+  ).toBeVisible();
+});
+
+test("expired cookie and unavailable profile never expose cached customer data", async ({
+  page,
+  context,
+}) => {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ sub: "1", exp: 1 })).toString(
+    "base64url",
+  );
+  const signature = createHmac(
+    "sha256",
+    "browser-tests-only-not-a-production-secret",
+  )
+    .update(`${header}.${payload}`)
+    .digest("base64url");
+  await context.addCookies([
+    {
+      name: "local-session",
+      value: `${header}.${payload}.${signature}`,
+      url: "http://127.0.0.1:3300",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+  ]);
+  await page.goto("/account");
+  await expect(
+    page.getByRole("heading", { name: "Sign in to view your account" }),
+  ).toBeVisible();
+  expect(
+    (await context.cookies()).some((cookie) => cookie.name === "local-session"),
+  ).toBe(false);
+  await page.route("**/api/session/me", (route) =>
+    route.fulfill({ status: 503, body: "{}" }),
+  );
+  await page.reload();
+  await expect(page.getByRole("main").getByRole("alert")).toContainText(
+    "temporarily unavailable",
+  );
+  await expect(
+    page.getByRole("region", { name: "Customer profile" }),
+  ).toHaveCount(0);
+  await page.unroute("**/api/session/me");
+  await page.getByRole("button", { name: "Try again" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Sign in to view your account" }),
+  ).toBeVisible();
+});
+
+test("restoring an account page revalidates and discards its previous profile", async ({
+  page,
+}) => {
+  await page.route("**/api/session/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        email: "demo@example.com",
+        created_at: "2026-09-01T12:00:00Z",
+      }),
+    }),
+  );
+  await page.goto("/account");
+  await expect(
+    page.getByText("demo@example.com", { exact: true }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: `test-results/profile-${test.info().project.name}.png`,
+  });
+  await page.evaluate(() =>
+    window.dispatchEvent(new PageTransitionEvent("pagehide")),
+  );
+  await expect(page.getByText("demo@example.com", { exact: true })).toHaveCount(
+    0,
+  );
+  await page.unroute("**/api/session/me");
+  await page.route("**/api/session/me", (route) =>
+    route.fulfill({ status: 401, body: "{}" }),
+  );
+  await page.evaluate(() =>
+    window.dispatchEvent(
+      new PageTransitionEvent("pageshow", { persisted: true }),
+    ),
+  );
+  await expect(
+    page.getByRole("heading", { name: "Sign in to view your account" }),
+  ).toBeVisible();
+  await expect(page.getByText("demo@example.com", { exact: true })).toHaveCount(
+    0,
   );
 });

--- a/frontend/tests/browser/account.spec.ts
+++ b/frontend/tests/browser/account.spec.ts
@@ -249,3 +249,47 @@ test("restoring an account page revalidates and discards its previous profile", 
     0,
   );
 });
+
+test("background account pages defer all profile requests until visible", async ({
+  page,
+}) => {
+  let requests = 0;
+  await page.addInitScript(() =>
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    }),
+  );
+  await page.route("**/api/session/me", (route) => {
+    requests++;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        email: "background@example.com",
+        created_at: "2026-09-01T12:00:00Z",
+      }),
+    });
+  });
+  await page.goto("/account");
+  await page.waitForLoadState("networkidle");
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event("focus"));
+    window.dispatchEvent(new PageTransitionEvent("pageshow"));
+  });
+  expect(requests).toBe(0);
+  await expect(
+    page.getByText("background@example.com", { exact: true }),
+  ).toHaveCount(0);
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  await expect(
+    page.getByText("background@example.com", { exact: true }),
+  ).toBeVisible();
+  expect(requests).toBe(2);
+});

--- a/frontend/tests/browser/catalog.spec.ts
+++ b/frontend/tests/browser/catalog.spec.ts
@@ -71,7 +71,9 @@ test("shared action and stock badge use the VINDOR theme", async ({ page }) => {
   await action.focus();
   await expect(action).toBeFocused();
   await expect(action).toHaveCSS("outline-style", "solid");
-  await expect(page.locator('[data-slot="badge"]')).toHaveText("Out of stock");
+  await expect(
+    page.getByRole("main").locator('[data-slot="badge"]'),
+  ).toHaveText("Out of stock");
 });
 
 test("mobile navigation supports keyboard, dismissal and real links", async ({
@@ -139,7 +141,7 @@ test("VINDOR branding and local photographs load", async ({ page }) => {
   await expect(page).toHaveTitle("VINDOR — Room to think");
   await expect(page.getByRole("link", { name: "VINDOR home" })).toHaveCount(2);
   await expect(page.getByRole("status")).toHaveText("6 objects");
-  const photos = page.locator("main img");
+  const photos = page.getByRole("main").locator("img");
   await expect(photos).toHaveCount(7);
   for (const photo of await photos.all()) {
     await photo.scrollIntoViewIfNeeded();


### PR DESCRIPTION
## Summary
Customers can now open **My account**, view their email and membership date, and sign out. Desktop and mobile navigation show the appropriate account link. Expired sessions prompt sign-in; service failures offer a retry.

## Issue
Closes #26 — Profile and account navigation.

## Acceptance criteria
- [x] Only the signed-in customer's profile is displayed.
- [x] Account navigation works on desktop and mobile.
- [x] Sign-out clears the session; returning to the account page does not restore private details.
- [x] Missing/expired sessions and service failures have tested recovery states.

## Testing
Validated locally on `ed06a5a`:

| Check | Result |
| --- | --- |
| Lint, formatting, TypeScript, API contract and production build | Passed |
| Unit tests | 52 passed |
| Browser tests | 25 passed; two mobile-only scenarios skipped on desktop |
| Accessibility and appearance | Axe checks passed; desktop/mobile screenshots inspected |

Browser coverage includes profile access, expired cookies, sign-out failure/retry, background tabs, browser restoration and private response caching. Tests use disposable data. Catalog assertions now exclude hidden React streaming markup.

## Review
Self-review completed, covering session privacy, request cancellation and logout behavior.

- [Codex review](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/66#issuecomment-5622957721): [Clean review of ed06a5a](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/66#issuecomment-5623229661); the finding is fixed and its thread resolved.
- [GitHub CI](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/66/checks): all verification jobs passed for ed06a5a.

## Deployment notes
Uses the existing session endpoints and configuration; no migration is required. Private profile data is fetched after page load and excluded from shared page HTML. Authentication transitions use full navigations to discard cached session UI. Sign-out clears the browser cookie but does not revoke a copied token before its expiry.

Production deploys after merge and successful main CI. Hosted development registration, login, profile navigation and UI logout passed on ed06a5a. Broader account journey verification remains in #27.


Delivery verified: PR #66 is merged. [Production delivery](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34512738605) completed successfully for `173ce83c1486c0f6a593d54ba04323ffb11019e3`. Production `/account`, API health and Swagger return HTTP 200; anonymous `/api/session/me` returns 401. The development registration → login → profile → logout flow passed. Wiki updated and #26 marked Done; shared-template improvements remain separate in #67.
