### PR TITLE
fix(auth): guard first-load forms and avoid guest sign-in reloads

### DIFF
--- a/docs/design/customer-sessions.md
+++ b/docs/design/customer-sessions.md
@@ -73,6 +73,10 @@ journey evidence; they do not replace session-handler tests in #24.
 
 `/register` and `/login` compose shadcn Input and Button with visible labels,
 native validation, pending states, focusable error feedback and keyboard access.
+Inputs and submission stay disabled until client handlers are ready. The form
+uses POST as a fallback and explains when JavaScript must be enabled. First
+submissions and service errors do not reload the page; successful login still
+uses a full navigation to clear previous session state.
 Registration asks users to sign in after success; it does not retry writes or
 silently authenticate. An uncertain response advises trying sign-in before
 registering again. Login always navigates to `/#collection`, ignoring query-string
@@ -92,7 +96,8 @@ shows a retry action without claiming the customer is signed out.
 Desktop and mobile navigation share a session lookup. The account page uses its
 own lookup boundary so session updates do not wrap streamed catalog content. It is revalidated on
 mount, page restoration, focus/visibility changes, and every minute while visible.
-Account links and successful sign-in use full navigations to prevent cached
+Guest sign-in links use client navigation without prefetching. Authenticated
+account links and successful sign-in use full navigations to prevent cached
 private screens from being restored by the client router. Hidden/leaving pages clear their profile snapshot; aborted or superseded
 requests cannot restore it. The sign-out button posts to the origin-checked
 logout handler and then performs a full navigation to `/login` to discard the

--- a/frontend/src/components/account-form.tsx
+++ b/frontend/src/components/account-form.tsx
@@ -1,13 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState, type FormEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type FormEvent,
+} from "react";
 import { ArrowLeft, CheckCircle2, LoaderCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
+// Server HTML must not accept credentials before React attaches submit handling.
+const subscribe = () => () => {};
+
 export function AccountForm({ mode }: { mode: "login" | "register" }) {
   const registering = mode === "register";
+  const ready = useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false,
+  );
   const [pending, setPending] = useState(false);
   const [error, setError] = useState("");
   const [registered, setRegistered] = useState(false);
@@ -19,7 +33,7 @@ export function AccountForm({ mode }: { mode: "login" | "register" }) {
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (busy.current) return;
+    if (!ready || busy.current) return;
     busy.current = true;
     setPending(true);
     setError("");
@@ -111,9 +125,10 @@ export function AccountForm({ mode }: { mode: "login" | "register" }) {
         </div>
       ) : (
         <form
+          method="post"
           onSubmit={submit}
           aria-label={registering ? "Create account" : "Sign in"}
-          aria-busy={pending}
+          aria-busy={!ready || pending}
           className="mt-8 space-y-5"
         >
           <div className="space-y-2">
@@ -127,7 +142,7 @@ export function AccountForm({ mode }: { mode: "login" | "register" }) {
               autoComplete="email"
               required
               maxLength={254}
-              disabled={pending}
+              disabled={!ready || pending}
               className="h-12"
             />
           </div>
@@ -144,7 +159,7 @@ export function AccountForm({ mode }: { mode: "login" | "register" }) {
               minLength={registering ? 8 : 1}
               maxLength={registering ? 128 : 1024}
               aria-describedby={registering ? "password-help" : undefined}
-              disabled={pending}
+              disabled={!ready || pending}
               className="h-12"
             />
             {registering && (
@@ -163,25 +178,43 @@ export function AccountForm({ mode }: { mode: "login" | "register" }) {
               {error}
             </p>
           )}
-          <Button type="submit" disabled={pending} className="h-12 w-full">
+          <Button
+            type="submit"
+            disabled={!ready || pending}
+            className="h-12 w-full transition-none"
+          >
             {pending && (
               <LoaderCircle
                 className="size-4 animate-spin motion-reduce:animate-none"
                 aria-hidden="true"
               />
             )}
-            {pending
+            {!ready
               ? registering
-                ? "Creating account…"
-                : "Signing in…"
-              : registering
-                ? "Create account"
-                : "Sign in"}
+                ? "Preparing registration…"
+                : "Preparing sign-in…"
+              : pending
+                ? registering
+                  ? "Creating account…"
+                  : "Signing in…"
+                : registering
+                  ? "Create account"
+                  : "Sign in"}
           </Button>
           <p role="status" className="sr-only">
-            {pending ? "Please wait while your request is processed." : ""}
+            {!ready
+              ? "Loading the secure form. Please wait."
+              : pending
+                ? "Please wait while your request is processed."
+                : ""}
           </p>
         </form>
+      )}
+      {!ready && (
+        <p className="mt-6 text-sm" role="status">
+          Loading the form. If this message remains, enable JavaScript and
+          reload the page.
+        </p>
       )}
       {!registered && (
         <p className="mt-6 text-center text-sm text-muted-foreground">

--- a/frontend/src/components/account-link.tsx
+++ b/frontend/src/components/account-link.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import { useSession } from "@/components/session-provider";
 export function AccountLink({
   className,
@@ -15,14 +16,20 @@ export function AccountLink({
       </span>
     );
   }
-  const guest = session.status === "guest";
+  if (session.status === "guest")
+    return (
+      <Link
+        href="/login"
+        prefetch={false}
+        className={className}
+        onClick={onClick}
+      >
+        Sign in
+      </Link>
+    );
   return (
-    <a
-      href={guest ? "/login" : "/account"}
-      className={className}
-      onClick={onClick}
-    >
-      {guest ? "Sign in" : "My account"}
+    <a href="/account" className={className} onClick={onClick}>
+      My account
     </a>
   );
 }

--- a/frontend/src/components/account-profile.tsx
+++ b/frontend/src/components/account-profile.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import { useRef, useState } from "react";
 import { LogOut, UserRound } from "lucide-react";
 import { useSession } from "@/components/session-provider";
@@ -48,7 +49,9 @@ export function AccountProfile() {
             Your session may have expired. Sign in to continue.
           </p>
           <Button asChild>
-            <a href="/login">Sign in</a>
+            <Link href="/login" prefetch={false}>
+              Sign in
+            </Link>
           </Button>
         </section>
       ) : session.status === "error" ? (

--- a/frontend/tests/browser/account.spec.ts
+++ b/frontend/tests/browser/account.spec.ts
@@ -293,3 +293,178 @@ test("background account pages defer all profile requests until visible", async 
   ).toBeVisible();
   expect(requests).toBe(2);
 });
+
+for (const mode of ["login", "register"] as const) {
+  test(`${mode} waits for delayed scripts before allowing the first submission`, async ({
+    page,
+  }) => {
+    let release!: () => void;
+    const scripts = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route("**/_next/static/**/*.js", async (route) => {
+      await scripts;
+      await route.continue();
+    });
+    let submissions = 0;
+    await page.route(`**/api/session/${mode}`, (route) => {
+      submissions++;
+      return route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: "{}",
+      });
+    });
+    try {
+      await page.goto(`/${mode}`, { waitUntil: "commit" });
+      const email = page.getByLabel("Email address");
+      const password = page.getByLabel("Password", { exact: true });
+      const submit = page.getByRole("main").getByRole("button");
+      await expect(email).toBeDisabled();
+      await expect(password).toBeDisabled();
+      await expect(submit).toBeDisabled();
+      await expect(submit).toContainText("Preparing");
+      expect(submissions).toBe(0);
+      release();
+      await expect(submit).toBeEnabled();
+      await email.fill("first-click@example.com");
+      await password.fill("fictional-first-click-password");
+      let documentRequests = 0;
+      page.on("request", (request) => {
+        if (
+          request.isNavigationRequest() &&
+          request.frame() === page.mainFrame()
+        )
+          documentRequests++;
+      });
+      await submit.click();
+      await expect(page.getByRole("main").getByRole("alert")).toBeVisible();
+      expect(submissions).toBe(1);
+      expect(documentRequests).toBe(0);
+      await expect(page).toHaveURL(new RegExp(`/${mode}$`));
+      await expect(email).toHaveValue("first-click@example.com");
+    } finally {
+      release();
+    }
+  });
+}
+
+test.describe("without JavaScript", () => {
+  test.use({ javaScriptEnabled: false });
+  test("account forms stay disabled and explain when JavaScript is unavailable", async ({
+    page,
+  }) => {
+    for (const mode of ["login", "register"]) {
+      await page.goto(`/${mode}`);
+      await expect(page.getByLabel("Email address")).toBeDisabled();
+      await expect(page.getByLabel("Password", { exact: true })).toBeDisabled();
+      await expect(page.getByRole("main").getByRole("button")).toBeDisabled();
+      await expect(
+        page.getByText(
+          "Loading the form. If this message remains, enable JavaScript and reload the page.",
+        ),
+      ).toBeVisible();
+    }
+  });
+});
+
+test("guest sign-in links navigate on the first click without reloading", async ({
+  page,
+}) => {
+  for (const source of ["header", "account"]) {
+    await page.goto("/account");
+    await expect(
+      page.getByRole("heading", { name: "Sign in to view your account" }),
+    ).toBeVisible();
+    if (source === "header" && test.info().project.name.includes("Pixel"))
+      await page.getByRole("button", { name: "Open navigation" }).click();
+    const signIn =
+      source === "account"
+        ? page
+            .getByRole("main")
+            .getByRole("link", { name: "Sign in", exact: true })
+        : page.getByRole("link", { name: "Sign in", exact: true }).first();
+    let documentRequests = 0;
+    const record = (request: import("@playwright/test").Request) => {
+      if (request.isNavigationRequest() && request.frame() === page.mainFrame())
+        documentRequests++;
+    };
+    page.on("request", record);
+    await signIn.click();
+    await expect(
+      page.getByRole("heading", { name: "Welcome back." }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Email address")).toBeEnabled();
+    expect(documentRequests).toBe(0);
+    page.off("request", record);
+  }
+});
+
+test("empty and incomplete sign-in submissions stay on the form without requests", async ({
+  page,
+}) => {
+  await page.goto("/login");
+  const submit = page.getByRole("button", { name: "Sign in", exact: true });
+  const email = page.getByLabel("Email address");
+  const password = page.getByLabel("Password", { exact: true });
+  await expect(submit).toBeEnabled();
+  let documents = 0;
+  let loginRequests = 0;
+  page.on("request", (request) => {
+    if (request.isNavigationRequest() && request.frame() === page.mainFrame())
+      documents++;
+    if (new URL(request.url()).pathname === "/api/session/login")
+      loginRequests++;
+  });
+  // The owner's exact report: the first click, with both fields untouched.
+  await submit.click();
+  await expect(email).toBeFocused();
+  expect(
+    await email.evaluate(
+      (el) => (el as HTMLInputElement).validity.valueMissing,
+    ),
+  ).toBe(true);
+  await email.fill("empty-password@example.com");
+  await submit.click();
+  await expect(password).toBeFocused();
+  expect(
+    await password.evaluate(
+      (el) => (el as HTMLInputElement).validity.valueMissing,
+    ),
+  ).toBe(true);
+  await email.fill("");
+  await password.fill("fictional-test-password");
+  await submit.click();
+  await expect(email).toBeFocused();
+  await email.fill("invalid-email");
+  await submit.click();
+  expect(
+    await email.evaluate(
+      (el) => (el as HTMLInputElement).validity.typeMismatch,
+    ),
+  ).toBe(true);
+  await expect(page).toHaveURL(/\/login$/);
+  expect(documents).toBe(0);
+  expect(loginRequests).toBe(0);
+});
+
+test("header sign-in on the login page does not reload or discard input", async ({
+  page,
+}) => {
+  await page.goto("/login");
+  await page.getByLabel("Email address").fill("navigation@example.com");
+  if (test.info().project.name.includes("Pixel"))
+    await page.getByRole("button", { name: "Open navigation" }).click();
+  let documents = 0;
+  page.on("request", (request) => {
+    if (request.isNavigationRequest() && request.frame() === page.mainFrame())
+      documents++;
+  });
+  await page.getByRole("link", { name: "Sign in", exact: true }).click();
+  await expect(page.getByLabel("Email address")).toBeVisible();
+  await expect(page.getByLabel("Email address")).toHaveValue(
+    "navigation@example.com",
+  );
+  await expect(page).toHaveURL(/\/login$/);
+  expect(documents).toBe(0);
+});


### PR DESCRIPTION
## Summary
Make guest Sign in links navigate without reloading the document, including when already on the login page. Keep login and registration controls disabled until their client handlers are ready, with loading guidance and a POST fallback.

The reported empty form-button click was checked on the existing production site: it already stayed on `/login` and focused the required email field in desktop/mobile Chromium. This PR adds explicit regression coverage for that exact case and fixes the separately reproduced header reload and early-submission defects.

## Issue
Closes #68. Shared PR-template cleanup remains separate in #67.

## Acceptance criteria
- [x] Forms wait for client readiness and explain unavailable JavaScript.
- [x] Empty/incomplete input makes no login request or document navigation.
- [x] Ready submissions send one request; failures preserve input and show feedback.
- [x] Guest links navigate without reloading, including the same-page header link.
- [x] Existing authenticated navigation, logout, expiry and private-data checks pass.

## Testing
| Check | Result |
| --- | --- |
| Production reproduction before changes | Empty form: zero requests/navigation; header link: one document reload. Delayed-script reproduction confirmed separately on development. |
| Playwright, complete suite | 37 passed; 2 expected desktop skips for mobile-only tests. Desktop Chrome and Pixel 7 emulation; disposable real FastAPI and fault fixtures. |
| Slow scripts / JavaScript disabled | Both forms remain disabled before readiness; normal first submission works after scripts load. |
| Accessibility and existing customer journey | axe checks and registration → login → profile → logout passed. |
| Unit tests | 52 passed. Coverage applies to configured catalog/session modules, not the entire frontend. |
| Lint, formatting, TypeScript, OpenAPI drift, production build | Passed. |

Local results cover commit `37a7f0b`. Safari/Firefox are not part of this browser run.

## Review
Self-review covered the complete diff, native validation, hydration, client navigation, duplicate submission and session boundaries. It also caught and corrected loading-feedback and transition-contrast issues before this final passing run. [Codex review](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/69#issuecomment-5624172788) completed cleanly for `37a7f0b9ebb94ab3a3c8dc2f4fd18b0bcdad4c9e`; no unresolved review threads. All applicable GitHub CI checks passed, including backend PostgreSQL/container tests and the frontend browser suite.

## Deployment / Compatibility
Frontend-only change; no API contract, migration, dependency or environment-variable changes. Successful login/logout and authenticated account links retain full navigations to discard stale private state. Guest links disable prefetching. Production deployment follows reviewed merge and successful main CI.

Hosted development verification passed on the same commit: desktop/mobile slow-load, empty-submit and guest-link checks; JavaScript-disabled guidance; and a fictional registration → login → profile → logout journey.


Production verified: [delivery run](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34520224830) successfully deployed `a9b12d3f522eccecf868d9cd81e6667832a6969e`. Desktop/mobile hosted checks passed for delayed scripts, empty submissions, same-page header navigation, guest account links and JavaScript-disabled guidance. Wiki updated.
