### PR TITLE
feat(cart): persist customer carts with stock-aware quantities

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The backend and catalog storefront run locally and in a
 | Verification | SQLite/PostgreSQL tests, container smoke tests, coverage gate, dependency audits |
 | Agent workflows | Root/backend/frontend instructions and scoped repository skills |
 | Frontend | Responsive catalog/detail and registration/login pages, filters, generated API types and browser checks |
-| Shopping | Cart, orders, payment processing, and order history are planned |
+| Shopping | [Signed-in cart API](docs/design/cart-api.md) persists quantities and calculates current GBP totals; cart UI, checkout, payments and order history remain planned |
 | Hosting | Development and production demos verified on Vercel/Neon; main releases through GitHub CI/CD |
 
 This repository is a development foundation, not a production-ready shop. Tests
@@ -223,7 +223,7 @@ Azure is an optional future migration (#31). The AWS Terraform in backend/infra
 remains legacy reference. No paid upgrade or new AI API billing is authorized.
 
 This is a [senior SWE portfolio project](docs/plans/portfolio.md).
-The next product steps are carts, orders and sandbox payments. The customer
+The next product steps are the cart storefront, orders and sandbox payments. The customer
 account journey is implemented and covered by desktop/mobile browser tests. Follow the
 [ordered roadmap](docs/plans/roadmap.md) for the remaining work.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -31,7 +31,8 @@ The initial migration targets an empty database. If an existing unversioned data
 contains tables, back it up and compare its schema before deciding whether to stamp
 the baseline. Never blindly stamp or drop an existing database to bypass errors.
 
-Cart, orders, payments, and frontend remain planned work.
+Signed-in cart persistence is documented in [the cart API guide](../docs/design/cart-api.md).
+The Next.js storefront and accounts are implemented; cart UI, checkout and payments remain planned.
 
 Registration returns 201. Login accepts form fields `username` (email) and
 `password`; use its bearer token for `/api/v1/auth/me`. Product reads are public;

--- a/backend/alembic/versions/0003_cart_lines.py
+++ b/backend/alembic/versions/0003_cart_lines.py
@@ -1,0 +1,33 @@
+"""Persistent customer cart lines.
+
+Revision ID: 0003
+Revises: 0002
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "cart_lines",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("product_id", sa.Integer(), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.CheckConstraint("quantity >= 1 AND quantity <= 99", name="ck_cart_quantity"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "product_id"),
+    )
+    op.create_index("ix_cart_lines_product_id", "cart_lines", ["product_id"])
+
+
+def downgrade():
+    op.drop_index("ix_cart_lines_product_id", table_name="cart_lines")
+    op.drop_table("cart_lines")

--- a/backend/alembic/versions/0003_cart_lines.py
+++ b/backend/alembic/versions/0003_cart_lines.py
@@ -15,6 +15,7 @@ depends_on = None
 
 
 def upgrade():
+    """Create cart storage with ownership, uniqueness and quantity constraints."""
     op.create_table(
         "cart_lines",
         sa.Column("user_id", sa.Integer(), nullable=False),
@@ -29,5 +30,6 @@ def upgrade():
 
 
 def downgrade():
+    """Remove cart storage; saved cart lines are lost on rollback."""
     op.drop_index("ix_cart_lines_product_id", table_name="cart_lines")
     op.drop_table("cart_lines")

--- a/backend/app/api/v1/cart.py
+++ b/backend/app/api/v1/cart.py
@@ -1,1 +1,61 @@
-# Cart endpoints
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Response
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.crud.cart import read_cart, remove_line, set_quantity
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.cart import CartQuantity, CartRead
+from app.schemas.errors import ErrorResponse
+
+router = APIRouter(responses={401: {"model": ErrorResponse}})
+ProductId = Annotated[int, Path(ge=1, le=2147483647)]
+
+
+def private_response(response: Response) -> None:
+    response.headers["Cache-Control"] = "private, no-store"
+
+
+router.dependencies.append(Depends(private_response))
+
+
+@router.get(
+    "/",
+    response_model=CartRead,
+    summary="Read your saved cart",
+    description="Current GBP prices and availability; stock is not reserved. Saved shortages remain visible. Deleted products are removed from carts.",
+)
+def get_cart(db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    return read_cart(db, user.id)
+
+
+@router.put(
+    "/items/{product_id}",
+    response_model=CartRead,
+    summary="Set an absolute cart quantity",
+    description="Idempotent quantity 1–99. New lines/increases require stock; reductions and unchanged quantities remain allowed during shortages. Concurrent writes serialize per customer: last serialized write wins. Prices and ownership cannot be supplied.",
+    responses={404: {"model": ErrorResponse}, 409: {"model": ErrorResponse}},
+)
+def put_cart_item(
+    product_id: ProductId,
+    payload: CartQuantity,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    return set_quantity(db, user.id, product_id, payload.quantity)
+
+
+@router.delete(
+    "/items/{product_id}",
+    status_code=204,
+    summary="Remove a product from your cart",
+    description="Idempotent: missing lines also return 204. Only your own line can be removed.",
+)
+def delete_cart_item(
+    product_id: ProductId,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    remove_line(db, user.id, product_id)

--- a/backend/app/api/v1/cart.py
+++ b/backend/app/api/v1/cart.py
@@ -15,6 +15,7 @@ ProductId = Annotated[int, Path(ge=1, le=2147483647)]
 
 
 def private_response(response: Response) -> None:
+    """Prevent successful cart responses from being cached."""
     response.headers["Cache-Control"] = "private, no-store"
 
 
@@ -28,6 +29,7 @@ router.dependencies.append(Depends(private_response))
     description="Current GBP prices and availability; stock is not reserved. Saved shortages remain visible. Deleted products are removed from carts.",
 )
 def get_cart(db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    """Return only the authenticated customer’s cart at current product prices."""
     return read_cart(db, user.id)
 
 
@@ -44,6 +46,7 @@ def put_cart_item(
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    """Set the customer’s absolute quantity using backend stock rules."""
     return set_quantity(db, user.id, product_id, payload.quantity)
 
 
@@ -58,4 +61,5 @@ def delete_cart_item(
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
+    """Remove only the customer’s line, succeeding even if it is absent."""
     remove_line(db, user.id, product_id)

--- a/backend/app/crud/cart.py
+++ b/backend/app/crud/cart.py
@@ -13,6 +13,7 @@ from app.schemas.product import ProductRead
 
 def read_cart(db: Session, user_id: int) -> CartRead:
     # One statement: prices, availability and quantities share the same snapshot.
+    """Read quantities and current prices together and calculate exact GBP totals."""
     rows = db.execute(
         select(CartLine, Product)
         .join(Product, Product.id == CartLine.product_id)
@@ -37,6 +38,7 @@ def read_cart(db: Session, user_id: int) -> CartRead:
 def lock_customer(db: Session, user_id: int) -> None:
     # Serialize mutations even when a cart has no rows yet. PostgreSQL is the
     # runtime; SQLite is only used for sequential behavioral tests.
+    """Serialize writes even for empty carts and recheck active status under lock."""
     user = db.scalar(
         select(User)
         .where(User.id == user_id)
@@ -48,6 +50,7 @@ def lock_customer(db: Session, user_id: int) -> None:
 
 
 def set_quantity(db: Session, user_id: int, product_id: int, quantity: int) -> CartRead:
+    """Commit an absolute quantity; stock limits apply only to new lines and increases."""
     lock_customer(db, user_id)
     product = db.scalar(
         select(Product)
@@ -73,6 +76,7 @@ def set_quantity(db: Session, user_id: int, product_id: int, quantity: int) -> C
 
 
 def remove_line(db: Session, user_id: int, product_id: int) -> None:
+    """Serialize and commit an idempotent removal scoped to the customer."""
     lock_customer(db, user_id)
     db.execute(
         delete(CartLine).where(

--- a/backend/app/crud/cart.py
+++ b/backend/app/crud/cart.py
@@ -1,1 +1,82 @@
-# Cart CRUD operations
+from decimal import Decimal
+
+from fastapi import HTTPException
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.models.cart import CartLine
+from app.models.product import Product
+from app.models.user import User
+from app.schemas.cart import CartItem, CartRead
+from app.schemas.product import ProductRead
+
+
+def read_cart(db: Session, user_id: int) -> CartRead:
+    # One statement: prices, availability and quantities share the same snapshot.
+    rows = db.execute(
+        select(CartLine, Product)
+        .join(Product, Product.id == CartLine.product_id)
+        .where(CartLine.user_id == user_id)
+        .order_by(CartLine.product_id)
+        .execution_options(populate_existing=True)
+    ).all()
+    items = [
+        CartItem(
+            product=ProductRead.model_validate(product),
+            quantity=line.quantity,
+            available=line.quantity <= product.stock,
+            line_total=product.price * line.quantity,
+        )
+        for line, product in rows
+    ]
+    return CartRead(
+        items=items, subtotal=sum((item.line_total for item in items), Decimal("0.00"))
+    )
+
+
+def lock_customer(db: Session, user_id: int) -> None:
+    # Serialize mutations even when a cart has no rows yet. PostgreSQL is the
+    # runtime; SQLite is only used for sequential behavioral tests.
+    user = db.scalar(
+        select(User)
+        .where(User.id == user_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+
+def set_quantity(db: Session, user_id: int, product_id: int, quantity: int) -> CartRead:
+    lock_customer(db, user_id)
+    product = db.scalar(
+        select(Product)
+        .where(Product.id == product_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    if product is None:
+        raise HTTPException(status_code=404, detail="Product not found")
+    line = db.get(CartLine, (user_id, product_id), populate_existing=True)
+    if (line is None or quantity > line.quantity) and quantity > product.stock:
+        raise HTTPException(
+            status_code=409, detail="Requested quantity exceeds current stock"
+        )
+    if line is None:
+        db.add(CartLine(user_id=user_id, product_id=product_id, quantity=quantity))
+    else:
+        line.quantity = quantity
+    db.flush()
+    result = read_cart(db, user_id)
+    db.commit()
+    return result
+
+
+def remove_line(db: Session, user_id: int, product_id: int) -> None:
+    lock_customer(db, user_id)
+    db.execute(
+        delete(CartLine).where(
+            CartLine.user_id == user_id, CartLine.product_id == product_id
+        )
+    )
+    db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
-from app.api.v1 import auth, products
+from app.api.v1 import auth, cart, products
 
 # --------------------------
 # Logging Configuration
@@ -23,7 +23,7 @@ app = FastAPI(
         "decimal prices. Product writes require an active admin. Register a customer, "
         "then use Authorize with your email in the username field to obtain a bearer "
         "token. Admin bootstrap is an operator CLI, never a public endpoint. "
-        "Cart and checkout are planned; no real purchases are supported."
+        "Signed-in carts use current prices without reserving stock; checkout is planned."
     ),
     openapi_tags=[
         {
@@ -85,6 +85,7 @@ async def health_check() -> dict[str, str]:
 # from app.api.v1 import products, users
 app.include_router(products.router, prefix="/api/v1/products", tags=["Products"])
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
+app.include_router(cart.router, prefix="/api/v1/cart", tags=["Cart"])
 # app.include_router(users.router, prefix="/api/v1/users", tags=["Users"])
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
+from app.models.cart import CartLine
 from app.models.product import Product
 from app.models.user import User
 
-__all__ = ["Product", "User"]
+__all__ = ["CartLine", "Product", "User"]

--- a/backend/app/models/cart.py
+++ b/backend/app/models/cart.py
@@ -1,1 +1,23 @@
-# Cart model
+from sqlalchemy import CheckConstraint, Column, ForeignKey, Integer
+
+from app.models.base import Base
+
+
+class CartLine(Base):
+    """The customer's active cart is its set of lines; an empty cart needs no row."""
+
+    __tablename__ = "cart_lines"
+    __table_args__ = (
+        CheckConstraint("quantity >= 1 AND quantity <= 99", name="ck_cart_quantity"),
+    )
+
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    product_id = Column(
+        Integer,
+        ForeignKey("products.id", ondelete="CASCADE"),
+        primary_key=True,
+        index=True,
+    )
+    quantity = Column(Integer, nullable=False)

--- a/backend/app/schemas/cart.py
+++ b/backend/app/schemas/cart.py
@@ -1,1 +1,32 @@
-# Cart schema
+from decimal import Decimal
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
+
+from app.schemas.product import ProductRead
+
+
+class CartQuantity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    quantity: Annotated[int, Field(strict=True, ge=1, le=99)]
+
+
+class CartItem(BaseModel):
+    product: ProductRead
+    quantity: int
+    available: bool
+    line_total: Decimal
+
+    @field_serializer("line_total", when_used="json")
+    def serialize_total(self, value: Decimal) -> str:
+        return format(value, ".2f")
+
+
+class CartRead(BaseModel):
+    items: list[CartItem]
+    currency: Literal["GBP"] = "GBP"
+    subtotal: Decimal
+
+    @field_serializer("subtotal", when_used="json")
+    def serialize_total(self, value: Decimal) -> str:
+        return format(value, ".2f")

--- a/backend/app/schemas/cart.py
+++ b/backend/app/schemas/cart.py
@@ -19,6 +19,7 @@ class CartItem(BaseModel):
 
     @field_serializer("line_total", when_used="json")
     def serialize_total(self, value: Decimal) -> str:
+        """Serialize exact GBP amounts with two fractional digits."""
         return format(value, ".2f")
 
 
@@ -29,4 +30,5 @@ class CartRead(BaseModel):
 
     @field_serializer("subtotal", when_used="json")
     def serialize_total(self, value: Decimal) -> str:
+        """Serialize exact GBP amounts with two fractional digits."""
         return format(value, ".2f")

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -6,7 +6,7 @@ os.environ["SECRET_KEY"] = "test-only-secret-key-that-is-at-least-32-characters"
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
@@ -24,6 +24,12 @@ def db():
         else {}
     )
     engine = create_engine(url, **options)
+    if engine.dialect.name == "sqlite":
+
+        @event.listens_for(engine, "connect")
+        def enable_foreign_keys(connection, _):
+            connection.execute("PRAGMA foreign_keys=ON")
+
     Base.metadata.create_all(engine)
     with Session(engine) as session:
         yield session

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -17,6 +17,7 @@ from app.models.base import Base
 
 @pytest.fixture
 def db():
+    """Provide an isolated disposable database, with foreign keys enabled on SQLite."""
     url = os.environ.get("TEST_DATABASE_URL", "sqlite://")
     options = (
         {"connect_args": {"check_same_thread": False}, "poolclass": StaticPool}
@@ -28,6 +29,7 @@ def db():
 
         @event.listens_for(engine, "connect")
         def enable_foreign_keys(connection, _):
+            """Enforce SQLite foreign keys so cascade tests cannot pass with orphaned rows."""
             connection.execute("PRAGMA foreign_keys=ON")
 
     Base.metadata.create_all(engine)
@@ -39,7 +41,10 @@ def db():
 
 @pytest.fixture
 def client(db):
+    """Route test requests to the disposable session and restore dependencies afterward."""
+
     def override_get_db():
+        """Supply the test session instead of the application database."""
         yield db
 
     app.dependency_overrides[get_db] = override_get_db
@@ -52,6 +57,7 @@ def client(db):
 
 @pytest.fixture
 def user(client, db):
+    """Register a fictional active customer through the public endpoint."""
     from app.models.user import User
 
     response = client.post(
@@ -64,6 +70,7 @@ def user(client, db):
 
 @pytest.fixture
 def token(user):
+    """Issue a test bearer token for the fixture customer."""
     from app.core.security import create_access_token
 
     return create_access_token(user.id)

--- a/backend/app/tests/test_cart.py
+++ b/backend/app/tests/test_cart.py
@@ -1,0 +1,230 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+from decimal import Decimal
+from threading import Barrier
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.security import create_access_token
+from app.crud.cart import set_quantity
+from app.models.cart import CartLine
+from app.models.product import Product
+from app.models.user import User
+
+
+@pytest.fixture
+def product(db):
+    item = Product(name="Cart test", price=Decimal("19.99"), stock=99)
+    db.add(item)
+    db.commit()
+    return item
+
+
+def headers(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def put(client, token, product, quantity, **extra):
+    return client.put(
+        f"/api/v1/cart/items/{product.id}",
+        headers=headers(token),
+        json={"quantity": quantity, **extra},
+    )
+
+
+def test_cart_current_money_stock_and_idempotence(client, db, product, token):
+    assert client.get("/api/v1/cart/", headers=headers(token)).json()["items"] == []
+    for _ in range(2):
+        result = put(client, token, product, 3)
+        assert result.status_code == 200
+        assert result.headers["cache-control"] == "private, no-store"
+        assert result.json()["subtotal"] == "59.97"
+        assert len(result.json()["items"]) == 1
+    product.price = Decimal("0.10")
+    product.stock = 1
+    db.commit()
+    result = client.get("/api/v1/cart/", headers=headers(token)).json()
+    assert result["subtotal"] == "0.30"
+    assert result["items"][0]["available"] is False
+    assert result["items"][0]["quantity"] == 3
+    assert put(client, token, product, 4).status_code == 409
+    assert put(client, token, product, 3).status_code == 200
+    assert put(client, token, product, 2).status_code == 200
+    assert put(client, token, product, 1).json()["items"][0]["available"] is True
+    for _ in range(2):
+        assert (
+            client.delete(
+                f"/api/v1/cart/items/{product.id}", headers=headers(token)
+            ).status_code
+            == 204
+        )
+    assert (
+        client.get("/api/v1/cart/", headers=headers(token)).json()["subtotal"] == "0.00"
+    )
+
+
+@pytest.mark.parametrize("quantity", [0, -1, 100, 1.5, "2", True, None])
+def test_invalid_quantity(client, product, token, quantity):
+    assert put(client, token, product, quantity).status_code == 422
+
+
+def test_stock_missing_and_untrusted_fields(client, db, product, token):
+    product.stock = 0
+    db.commit()
+    assert put(client, token, product, 1).status_code == 409
+    for field in ("user_id", "price", "subtotal", "product_id"):
+        assert put(client, token, product, 1, **{field: 1}).status_code == 422
+    assert (
+        client.put(
+            "/api/v1/cart/items/2147483647",
+            headers=headers(token),
+            json={"quantity": 1},
+        ).status_code
+        == 404
+    )
+    assert (
+        client.put(
+            "/api/v1/cart/items/0", headers=headers(token), json={"quantity": 1}
+        ).status_code
+        == 422
+    )
+
+
+def test_auth_and_customer_isolation(client, db, product, user, token):
+    assert put(client, token, product, 2).status_code == 200
+    other = User(email="other@example.com", hashed_password="unused", is_active=True)
+    db.add(other)
+    db.commit()
+    other_token = create_access_token(other.id)
+    assert (
+        client.get("/api/v1/cart/", headers=headers(other_token)).json()["items"] == []
+    )
+    assert (
+        client.delete(
+            f"/api/v1/cart/items/{product.id}", headers=headers(other_token)
+        ).status_code
+        == 204
+    )
+    assert put(client, other_token, product, 4).status_code == 200
+    assert (
+        client.get("/api/v1/cart/", headers=headers(token)).json()["items"][0][
+            "quantity"
+        ]
+        == 2
+    )
+    expired = create_access_token(user.id, expires_delta=timedelta(seconds=-1))
+    for auth in ({}, headers(expired)):
+        assert client.get("/api/v1/cart/", headers=auth).status_code == 401
+        assert (
+            client.put(
+                f"/api/v1/cart/items/{product.id}", headers=auth, json={"quantity": 1}
+            ).status_code
+            == 401
+        )
+        assert (
+            client.delete(f"/api/v1/cart/items/{product.id}", headers=auth).status_code
+            == 401
+        )
+    user.is_active = False
+    db.commit()
+    assert put(client, token, product, 1).status_code == 401
+    assert client.get("/api/v1/cart/", headers=headers(token)).status_code == 401
+    assert (
+        client.delete(
+            f"/api/v1/cart/items/{product.id}", headers=headers(token)
+        ).status_code
+        == 401
+    )
+
+
+def test_persistence_and_product_deletion(client, db, product, user, token):
+    assert put(client, token, product, 99).status_code == 200
+    # New DB session (as after process restart), and a fresh login/token.
+    with Session(db.get_bind()) as fresh:
+        assert fresh.get(CartLine, (user.id, product.id)).quantity == 99
+    login = client.post(
+        "/api/v1/auth/login", data={"username": user.email, "password": "password123"}
+    )
+    assert (
+        client.get(
+            "/api/v1/cart/", headers=headers(login.json()["access_token"])
+        ).json()["items"][0]["quantity"]
+        == 99
+    )
+    user.is_superuser = True
+    db.commit()
+    assert (
+        client.delete(
+            f"/api/v1/products/{product.id}", headers=headers(token)
+        ).status_code
+        == 204
+    )
+    assert client.get("/api/v1/cart/", headers=headers(token)).json()["items"] == []
+    assert db.scalar(select(func.count()).select_from(CartLine)) == 0
+
+
+def test_database_constraints(db, product, user):
+    for user_id, product_id, quantity in [
+        (user.id, product.id, 0),
+        (user.id, product.id, 100),
+        (2147483647, product.id, 1),
+        (user.id, 2147483647, 1),
+    ]:
+        db.add(CartLine(user_id=user_id, product_id=product_id, quantity=quantity))
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+
+def test_postgres_concurrent_duplicate_and_updates(db, product, user):
+    if db.get_bind().dialect.name != "postgresql":
+        pytest.skip("PostgreSQL row-lock semantics are verified in integration CI")
+    uid, pid = user.id, product.id
+    db.commit()
+    for quantities in ((2, 2), (3, 4)):
+        barrier = Barrier(2)
+
+        def worker(quantity):
+            with Session(db.get_bind()) as session:
+                barrier.wait(timeout=10)
+                return set_quantity(session, uid, pid, quantity)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(worker, quantities))
+        assert all(len(result.items) == 1 for result in results)
+        db.expire_all()
+        assert db.get(CartLine, (uid, pid)).quantity in quantities
+        assert db.scalar(select(func.count()).select_from(CartLine)) == 1
+        db.commit()
+
+
+def test_multiple_products_and_maximum_money(client, db, product, token):
+    product.price = Decimal("9999999999.99")
+    second = Product(name="Second", price=Decimal("0.01"), stock=2)
+    db.add(second)
+    db.commit()
+    assert put(client, token, product, 99).status_code == 200
+    result = put(client, token, second, 2).json()
+    assert result["subtotal"] == "989999999999.03"
+    assert [item["product"]["id"] for item in result["items"]] == [
+        product.id,
+        second.id,
+    ]
+
+
+def test_unique_line_and_customer_cascade(db, product, user):
+    uid, pid = user.id, product.id
+    db.add(CartLine(user_id=uid, product_id=pid, quantity=1))
+    db.commit()
+    from sqlalchemy import insert
+
+    with pytest.raises(IntegrityError):
+        db.execute(insert(CartLine).values(user_id=uid, product_id=pid, quantity=2))
+        db.commit()
+    db.rollback()
+    db.delete(user)
+    db.commit()
+    assert db.scalar(select(func.count()).select_from(CartLine)) == 0

--- a/backend/app/tests/test_cart.py
+++ b/backend/app/tests/test_cart.py
@@ -17,6 +17,7 @@ from app.models.user import User
 
 @pytest.fixture
 def product(db):
+    """Persist a fictional product with enough stock for quantity boundary tests."""
     item = Product(name="Cart test", price=Decimal("19.99"), stock=99)
     db.add(item)
     db.commit()
@@ -24,10 +25,12 @@ def product(db):
 
 
 def headers(token):
+    """Build bearer headers without exposing the token in test output."""
     return {"Authorization": f"Bearer {token}"}
 
 
 def put(client, token, product, quantity, **extra):
+    """Submit an absolute quantity with optional fields for rejection tests."""
     return client.put(
         f"/api/v1/cart/items/{product.id}",
         headers=headers(token),
@@ -36,6 +39,7 @@ def put(client, token, product, quantity, **extra):
 
 
 def test_cart_current_money_stock_and_idempotence(client, db, product, token):
+    """Verify retries, live prices, visible shortages, reductions and repeat removal."""
     assert client.get("/api/v1/cart/", headers=headers(token)).json()["items"] == []
     for _ in range(2):
         result = put(client, token, product, 3)
@@ -68,10 +72,12 @@ def test_cart_current_money_stock_and_idempotence(client, db, product, token):
 
 @pytest.mark.parametrize("quantity", [0, -1, 100, 1.5, "2", True, None])
 def test_invalid_quantity(client, product, token, quantity):
+    """Reject out-of-range values and coercions such as strings and booleans."""
     assert put(client, token, product, quantity).status_code == 422
 
 
 def test_stock_missing_and_untrusted_fields(client, db, product, token):
+    """Reject unavailable additions, missing products and client authority fields."""
     product.stock = 0
     db.commit()
     assert put(client, token, product, 1).status_code == 409
@@ -94,6 +100,7 @@ def test_stock_missing_and_untrusted_fields(client, db, product, token):
 
 
 def test_auth_and_customer_isolation(client, db, product, user, token):
+    """Keep carts separate and deny anonymous, expired and disabled credentials."""
     assert put(client, token, product, 2).status_code == 200
     other = User(email="other@example.com", hashed_password="unused", is_active=True)
     db.add(other)
@@ -141,6 +148,7 @@ def test_auth_and_customer_isolation(client, db, product, user, token):
 
 
 def test_persistence_and_product_deletion(client, db, product, user, token):
+    """Restore saved lines across sessions and remove them when products are deleted."""
     assert put(client, token, product, 99).status_code == 200
     # New DB session (as after process restart), and a fresh login/token.
     with Session(db.get_bind()) as fresh:
@@ -167,6 +175,7 @@ def test_persistence_and_product_deletion(client, db, product, user, token):
 
 
 def test_database_constraints(db, product, user):
+    """Reject invalid quantities and orphaned ownership references at the database."""
     for user_id, product_id, quantity in [
         (user.id, product.id, 0),
         (user.id, product.id, 100),
@@ -180,6 +189,7 @@ def test_database_constraints(db, product, user):
 
 
 def test_postgres_concurrent_duplicate_and_updates(db, product, user):
+    """Verify separate PostgreSQL transactions cannot create duplicate customer lines."""
     if db.get_bind().dialect.name != "postgresql":
         pytest.skip("PostgreSQL row-lock semantics are verified in integration CI")
     uid, pid = user.id, product.id
@@ -188,6 +198,7 @@ def test_postgres_concurrent_duplicate_and_updates(db, product, user):
         barrier = Barrier(2)
 
         def worker(quantity):
+            """Race an independent transaction against the other absolute quantity write."""
             with Session(db.get_bind()) as session:
                 barrier.wait(timeout=10)
                 return set_quantity(session, uid, pid, quantity)
@@ -202,6 +213,7 @@ def test_postgres_concurrent_duplicate_and_updates(db, product, user):
 
 
 def test_multiple_products_and_maximum_money(client, db, product, token):
+    """Sum multiple lines exactly even when totals exceed the product price range."""
     product.price = Decimal("9999999999.99")
     second = Product(name="Second", price=Decimal("0.01"), stock=2)
     db.add(second)
@@ -216,6 +228,7 @@ def test_multiple_products_and_maximum_money(client, db, product, token):
 
 
 def test_unique_line_and_customer_cascade(db, product, user):
+    """Reject duplicate lines and cascade customer deletion to saved cart data."""
     uid, pid = user.id, product.id
     db.add(CartLine(user_id=uid, product_id=pid, quantity=1))
     db.commit()

--- a/backend/app/tests/test_migrations.py
+++ b/backend/app/tests/test_migrations.py
@@ -28,7 +28,7 @@ def test_migration_upgrade_downgrade_and_metadata(tmp_path):
     alembic("upgrade", "head")
     alembic("check")
     engine = create_engine(database_url)
-    assert {"users", "products"} <= set(inspect(engine).get_table_names())
+    assert {"users", "products", "cart_lines"} <= set(inspect(engine).get_table_names())
     alembic("downgrade", "base")
     assert "users" not in inspect(engine).get_table_names()
     alembic("upgrade", "head")

--- a/backend/app/tests/test_migrations.py
+++ b/backend/app/tests/test_migrations.py
@@ -9,12 +9,14 @@ BACKEND = Path(__file__).resolve().parents[2]
 
 
 def test_migration_upgrade_downgrade_and_metadata(tmp_path):
+    """Verify repeatable migrations, metadata and cart constraints on disposable storage."""
     database_url = os.environ.get(
         "TEST_MIGRATION_DATABASE_URL", f"sqlite:///{tmp_path / 'migration.db'}"
     )
     env = dict(os.environ, DATABASE_URL=database_url)
 
     def alembic(*args):
+        """Run a checked migration command against the disposable test database."""
         subprocess.run(
             [sys.executable, "-m", "alembic", *args],
             cwd=BACKEND,
@@ -62,6 +64,7 @@ def test_migration_upgrade_downgrade_and_metadata(tmp_path):
 
 # TEST_MIGRATION_DATABASE_URL, when set, must point to a separate disposable DB.
 def test_existing_product_migration_preserves_money_and_rejects_loss(tmp_path):
+    """Preserve valid legacy prices and reject migration that would lose precision."""
     from decimal import Decimal
 
     from sqlalchemy import MetaData, Table, text
@@ -72,6 +75,7 @@ def test_existing_product_migration_preserves_money_and_rejects_loss(tmp_path):
     env = dict(os.environ, DATABASE_URL=url)
 
     def migrate(*args, check=True):
+        """Run legacy migration steps, optionally retaining an expected failure result."""
         return subprocess.run(
             [sys.executable, "-m", "alembic", *args],
             cwd=BACKEND,

--- a/backend/app/tests/test_migrations.py
+++ b/backend/app/tests/test_migrations.py
@@ -29,6 +29,30 @@ def test_migration_upgrade_downgrade_and_metadata(tmp_path):
     alembic("check")
     engine = create_engine(database_url)
     assert {"users", "products", "cart_lines"} <= set(inspect(engine).get_table_names())
+    schema = inspect(engine)
+    assert schema.get_pk_constraint("cart_lines")["constrained_columns"] == [
+        "user_id",
+        "product_id",
+    ]
+    assert {
+        constraint["name"] for constraint in schema.get_check_constraints("cart_lines")
+    } == {"ck_cart_quantity"}
+    check = schema.get_check_constraints("cart_lines")[0]["sqltext"]
+    normalized = "".join(check.replace("(", "").replace(")", "").split()).lower()
+    assert normalized == "quantity>=1andquantity<=99"
+    foreign_keys = schema.get_foreign_keys("cart_lines")
+    assert {
+        (
+            tuple(key["constrained_columns"]),
+            key["referred_table"],
+            tuple(key["referred_columns"]),
+            key["options"].get("ondelete"),
+        )
+        for key in foreign_keys
+    } == {
+        (("user_id",), "users", ("id",), "CASCADE"),
+        (("product_id",), "products", ("id",), "CASCADE"),
+    }
     alembic("downgrade", "base")
     assert "users" not in inspect(engine).get_table_names()
     alembic("upgrade", "head")

--- a/docs/api.md
+++ b/docs/api.md
@@ -39,6 +39,12 @@ To explore customer authentication:
 2. Click **Authorize**. Enter that email in `username` and the password in
    `password`; leave client credentials empty. Swagger obtains a bearer token.
 3. Execute `GET /api/v1/auth/me` to inspect the authenticated profile.
+4. Choose an in-stock product ID from the catalog. Execute
+   `PUT /api/v1/cart/items/{product_id}` with `{"quantity": 1}`.
+5. Execute `GET /api/v1/cart/` to see the saved line, current GBP price, exact
+   subtotal and availability. Repeat the PUT: the absolute quantity stays 1.
+6. Execute `DELETE /api/v1/cart/items/{product_id}` to remove the line (204).
+   GET the cart again to confirm it is empty.
 
 Public signup creates a customer. Product writes require an active admin created
 through the explicit CLI in [demo setup](demo.md); no public endpoint promotes
@@ -118,10 +124,18 @@ personal data before sharing logs. Restart the stack after restarting your machi
 if the services are no longer running.
 
 The schema documents request/response models, bearer security requirements,
-pagination bounds, and 400/401/403/404 errors where applicable. FastAPI documents
+pagination bounds, and 400/401/403/404/409 errors where applicable. FastAPI documents
 422 validation errors. Products return prices as exact two-place GBP strings;
 PUT keeps omitted fields and allows null only for description. Health is liveness,
-not database readiness. No cart, checkout or payment endpoints are claimed yet.
+not database readiness.
+
+Cart GET/PUT/DELETE operations require an active customer's bearer token. Cart PUT
+sets an integer quantity from 1 to 99; new lines and increases beyond current stock
+return 409. Reductions and removal remain allowed during shortages. Cart totals
+use current backend prices, and adding a line does not reserve stock. Deleted
+products are removed from saved carts. See [the cart contract](design/cart-api.md)
+for persistence and concurrency semantics. Cart storefront controls, checkout and
+payment endpoints remain planned.
 
 ## Contract workflow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,15 +1,14 @@
 # Current architecture
 
-FastAPI exposes /health and /api/v1/auth and /api/v1/products. SQLAlchemy models
-currently represent users and products. PostgreSQL is the development runtime;
+FastAPI exposes /health and /api/v1/auth and /api/v1/products and /api/v1/cart. SQLAlchemy models
+represent users, products and customer cart lines. PostgreSQL is the development runtime;
 SQLite is used for isolated unit/API tests. Alembic controls database schema.
 
 The frontend/ directory provides the Next.js catalog and product-detail storefront.
 Tailwind v4 and shadcn/ui supply shared themed primitives; page layouts compose reusable storefront components. See [frontend design system](../frontend/design-system.md).
 Server-side calls use generated OpenAPI types and an internal API_BASE_URL; the
-browser receives product data for local filtering. Cart, orders and payment
-adapters are not implemented.
-Existing files for those domains are placeholders. Product prices use Decimal /
+browser receives product data for local filtering. Signed-in cart persistence is implemented; see [cart API](design/cart-api.md).
+Cart UI, orders and payment adapters remain planned. Product prices use Decimal /
 NUMERIC(12, 2), carry GBP currency, and serialize as two-place decimal strings.
 API validation and database constraints protect catalog values.
 

--- a/docs/design/cart-api.md
+++ b/docs/design/cart-api.md
@@ -1,0 +1,50 @@
+# Persistent cart API
+
+Each active signed-in customer has one logical cart: rows in `cart_lines`, keyed
+by `(user_id, product_id)`. An empty cart has no rows. Bearer authentication uses
+the existing active-user dependency; clients cannot supply ownership or prices.
+The storefront integration is tracked separately in #72.
+
+## Contract
+
+- `GET /api/v1/cart/`: current items, product details, quantity, `available`,
+  two-place GBP `line_total` and `subtotal`. Successful responses are private/no-store.
+- `PUT /api/v1/cart/items/{product_id}` with `{"quantity": 2}`: set an absolute
+  integer quantity from 1 to 99 and return the updated cart. Extra fields are
+  rejected. A missing product returns 404; insufficient stock for a new line or
+  increase returns 409. Invalid bodies/identifiers return 422.
+- `DELETE /api/v1/cart/items/{product_id}`: remove your own line; return 204 even
+  if absent. There is no endpoint taking another customer's ID or a cart-line ID.
+
+Example in Swagger: register, authorize with email/password, obtain a product ID
+from the public catalog, PUT its quantity, GET the cart, then DELETE the line.
+A fresh login restores saved rows. Tokens are not persisted in the cart.
+
+## Prices, stock and transactions
+
+Prices are current backend product prices, calculated using Decimal; carts do
+not freeze prices or reserve inventory. A later shortage retains the saved
+quantity and returns `available: false`. Unchanged quantities and reductions
+remain permitted even when still above stock. Checkout (#29) must independently
+revalidate prices and reserve inventory atomically before creating an order.
+
+PostgreSQL mutations lock the customer row, including an initially empty cart,
+then the affected product for quantity writes. Concurrent writes to a customer's
+cart serialize; the last serialized absolute write wins. Repeating a PUT does
+not add quantities or duplicate lines. Deletion participates in the same customer
+lock. Responses reflect a transaction snapshot, not a guarantee against later
+changes. Reads obtain quantities and product prices in one SQL statement.
+
+The composite primary key prevents duplicate products per customer; foreign keys
+cascade product/customer deletion, and a check constraint enforces quantity
+bounds. Deleting a product intentionally removes it from all carts. Migration
+0003 only adds a table/index; it does not modify existing users or products.
+Production applies it through the existing deployment workflow.
+
+## Verification
+
+`make check` covers API behavior, ownership, invalid input, exact money,
+persistence, deletion and migration metadata. The PostgreSQL CI job runs the same
+suite plus concurrent requests using separate database sessions. SQLite tests are
+sequential and explicitly enable foreign keys; they do not claim to validate row
+locks. All tests use disposable databases.

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -39,7 +39,7 @@ account, cart and checkout components are added with their feature tickets.
 ## Next PRs, in dependency order
 
 1. Finish frontend PR previews with safe development data and exact origins (#45).
-2. Persistent carts: ownership, quantity changes/removal, stock checks, API and UI.
+2. Cart storefront (#72), building on the persistent signed-in [cart API](../design/cart-api.md) (#71): quantity changes/removal, availability and the complete customer journey.
 3. Orders and checkout: price snapshots, authoritative totals, atomic inventory
    handling, idempotency, and concurrent last-item purchase tests.
 4. Sandbox payments: verify webhooks, handle duplicate/failure/cancellation events,
@@ -69,4 +69,4 @@ broader items into focused PR tickets before implementation. See
 
 Hosting setup #44 and production workflow acceptance #46 are complete.
 Development and production are live; #45 tracks the remaining frontend previews.
-Account journey verification (#27) is complete; persistent carts (#28) are the next product task. Azure is deferred; no extra API billing is allowed.
+Account journey verification (#27) is complete; the cart storefront (#72) is the next product task after the persistent API (#71). Azure is deferred; no extra API billing is allowed.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -60,6 +60,76 @@
         "title": "Body_login_api_v1_auth_login_post",
         "type": "object"
       },
+      "CartItem": {
+        "properties": {
+          "available": {
+            "title": "Available",
+            "type": "boolean"
+          },
+          "line_total": {
+            "title": "Line Total",
+            "type": "string"
+          },
+          "product": {
+            "$ref": "#/components/schemas/ProductRead"
+          },
+          "quantity": {
+            "title": "Quantity",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "product",
+          "quantity",
+          "available",
+          "line_total"
+        ],
+        "title": "CartItem",
+        "type": "object"
+      },
+      "CartQuantity": {
+        "additionalProperties": false,
+        "properties": {
+          "quantity": {
+            "maximum": 99.0,
+            "minimum": 1.0,
+            "title": "Quantity",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "quantity"
+        ],
+        "title": "CartQuantity",
+        "type": "object"
+      },
+      "CartRead": {
+        "properties": {
+          "currency": {
+            "const": "GBP",
+            "default": "GBP",
+            "title": "Currency",
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CartItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "subtotal": {
+            "title": "Subtotal",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items",
+          "subtotal"
+        ],
+        "title": "CartRead",
+        "type": "object"
+      },
       "ErrorResponse": {
         "description": "HTTP errors use a detail string; validation errors have FastAPI's 422 schema.",
         "properties": {
@@ -401,7 +471,7 @@
     }
   },
   "info": {
-    "description": "Portfolio ecommerce API backed by PostgreSQL. Public catalog reads use GBP decimal prices. Product writes require an active admin. Register a customer, then use Authorize with your email in the username field to obtain a bearer token. Admin bootstrap is an operator CLI, never a public endpoint. Cart and checkout are planned; no real purchases are supported.",
+    "description": "Portfolio ecommerce API backed by PostgreSQL. Public catalog reads use GBP decimal prices. Product writes require an active admin. Register a customer, then use Authorize with your email in the username field to obtain a bearer token. Admin bootstrap is an operator CLI, never a public endpoint. Signed-in carts use current prices without reserving stock; checkout is planned.",
     "title": "E-Commerce API",
     "version": "0.1.0"
   },
@@ -545,6 +615,184 @@
         "summary": "Register a customer account",
         "tags": [
           "auth"
+        ]
+      }
+    },
+    "/api/v1/cart/": {
+      "get": {
+        "description": "Current GBP prices and availability; stock is not reserved. Saved shortages remain visible. Deleted products are removed from carts.",
+        "operationId": "get_cart_api_v1_cart__get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CartRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Read your saved cart",
+        "tags": [
+          "Cart"
+        ]
+      }
+    },
+    "/api/v1/cart/items/{product_id}": {
+      "delete": {
+        "description": "Idempotent: missing lines also return 204. Only your own line can be removed.",
+        "operationId": "delete_cart_item_api_v1_cart_items__product_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "title": "Product Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Remove a product from your cart",
+        "tags": [
+          "Cart"
+        ]
+      },
+      "put": {
+        "description": "Idempotent quantity 1\u201399. New lines/increases require stock; reductions and unchanged quantities remain allowed during shortages. Concurrent writes serialize per customer: last serialized write wins. Prices and ownership cannot be supplied.",
+        "operationId": "put_cart_item_api_v1_cart_items__product_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "title": "Product Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CartQuantity"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CartRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Set an absolute cart quantity",
+        "tags": [
+          "Cart"
         ]
       }
     },

--- a/frontend/src/lib/api/schema.d.ts
+++ b/frontend/src/lib/api/schema.d.ts
@@ -65,6 +65,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/cart/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read your saved cart
+         * @description Current GBP prices and availability; stock is not reserved. Saved shortages remain visible. Deleted products are removed from carts.
+         */
+        get: operations["get_cart_api_v1_cart__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/cart/items/{product_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Set an absolute cart quantity
+         * @description Idempotent quantity 1–99. New lines/increases require stock; reductions and unchanged quantities remain allowed during shortages. Concurrent writes serialize per customer: last serialized write wins. Prices and ownership cannot be supplied.
+         */
+        put: operations["put_cart_item_api_v1_cart_items__product_id__put"];
+        post?: never;
+        /**
+         * Remove a product from your cart
+         * @description Idempotent: missing lines also return 204. Only your own line can be removed.
+         */
+        delete: operations["delete_cart_item_api_v1_cart_items__product_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/products/": {
         parameters: {
             query?: never;
@@ -162,6 +206,34 @@ export interface components {
             scope: string;
             /** Username */
             username: string;
+        };
+        /** CartItem */
+        CartItem: {
+            /** Available */
+            available: boolean;
+            /** Line Total */
+            line_total: string;
+            product: components["schemas"]["ProductRead"];
+            /** Quantity */
+            quantity: number;
+        };
+        /** CartQuantity */
+        CartQuantity: {
+            /** Quantity */
+            quantity: number;
+        };
+        /** CartRead */
+        CartRead: {
+            /**
+             * Currency
+             * @default GBP
+             * @constant
+             */
+            currency: "GBP";
+            /** Items */
+            items: components["schemas"]["CartItem"][];
+            /** Subtotal */
+            subtotal: string;
         };
         /**
          * ErrorResponse
@@ -383,6 +455,135 @@ export interface operations {
             };
             /** @description Email is already registered. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cart_api_v1_cart__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CartRead"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    put_cart_item_api_v1_cart_items__product_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                product_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CartQuantity"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CartRead"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_cart_item_api_v1_cart_items__product_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                product_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Summary
Persist each signed-in customer's cart across sessions. Customers can read their cart, set an absolute product quantity, and remove a line; FastAPI calculates current GBP totals and reports stock shortages without silently changing saved quantities.

## Issue
Closes #71. Refs #28. Storefront controls remain the dependent #72.

## Acceptance criteria
- [x] Composite customer/product key, quantity constraint and cascading deletion in migration 0003.
- [x] Active-user ownership, strict quantity validation, idempotent writes and stock rules.
- [x] Current prices, exact GBP totals and explicit availability; no stock reservation.
- [x] OpenAPI, generated frontend types and cart onboarding updated.
- [x] API, persistence, isolation, constraints and PostgreSQL concurrency tests added.
- [ ] PostgreSQL/container CI and current-head external review pass.
- [ ] Deployment applies the migration and passes verification.

## Testing
- Backend lint/format and full suite: 92 passed, 2 PostgreSQL-only skips; coverage 92.5%.
- Additional maximum-money and customer-cascade checks: final cart suite 14 passed, 1 PostgreSQL-only skip.
- Migration upgrade/downgrade/metadata checks passed on disposable SQLite.
- Frontend API generation and typecheck passed.
- Prior-head PostgreSQL and container CI passed; final-head CI is rerunning after documentation follow-up.
- Local Docker daemon unavailable; PostgreSQL row locking and container rollout require CI. No production test data was created.

## Review
Self-review covered ownership, lock ordering, deletion, money precision and migration consistency. CodeRabbit requested explicit migrated-constraint assertions; added and verified in 11a4bff, with the thread resolved. Codex subsequently found stale wording in docs/api.md; corrected the canonical walkthrough and summary in 6f289f9 and resolved the thread. Fresh final-head review is pending.

## Deployment / Compatibility
Additive migration 0003 creates cart_lines. Existing users/products are unchanged. Product deletion intentionally removes its cart lines. Production remains PostgreSQL; SQLite only provides sequential test coverage. Checkout and cart UI are outside this PR.
