### PR TITLE
docs: persist framework guidance and delivery checkpoints

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -12,3 +12,7 @@ Use [self-review](../self-review/SKILL.md) before requesting external review. Fi
 Within existing push/PR authorization, commit and push the intended changes, then create or refresh the PR using gh/API. Pass multiline text through a body file or structured JSON, never shell interpolation of PR content. Apply the ownership helper and read back title, base/head, body, owner assignment and labels. Request only Codex using the current-head protocol in [review documentation](../../../docs/codex-review.md); avoid duplicate requests for an unchanged head.
 
 Use [update-delivery-board](../update-delivery-board/SKILL.md) to move the linked ticket to In review. Report the PR URL, checks and review state. Creating a PR does not itself authorize merging or deployment; continue a separately authorized delivery task under the repository merge policy.
+
+Follow AGENTS.md for small coherent commits and regular verified pushes within
+existing authorization. Keep code and its tests together; do not save all changes
+for one final large commit. A push does not waive fresh current-head review.

--- a/.agents/skills/ecommerce-backend/SKILL.md
+++ b/.agents/skills/ecommerce-backend/SKILL.md
@@ -19,3 +19,8 @@ stack for PostgreSQL checks. Do not stamp or downgrade an existing user database
 
 Run make check; require container CI for database or startup changes. Regenerate
 OpenAPI-derived frontend types when that frontend has been introduced.
+
+Consult the installed official FastAPI skill and relevant references before
+implementation; [framework guidance](../../../docs/framework-agent-guidance.md)
+explains discovery. Apply compatible patterns without replacing the approved
+SQLAlchemy stack or expanding the task to an unsolicited framework migration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,15 @@ README, Wiki and contract documentation. Read the selected SKILL.md under
 .agents/skills before using it. These reuse the policies above; they do not
 replace external review or expand authorization. See docs/delivery-skills.md
 for invocation and discovery, including tasks started outside the repository.
+
+## Framework guidance and incremental delivery
+
+Before framework changes, read the installed version-matched documentation and
+applicable official skills as described in [framework guidance](docs/framework-agent-guidance.md).
+Keep project architecture and security constraints authoritative.
+
+Make small, coherent Conventional Commits after relevant checks and staged-diff
+review. Keep coupled code, tests and generated outputs together; do not split by
+arbitrary line counts. Within push authorization, push each verified milestone
+regularly rather than accumulating the entire feature locally. Report blockers
+and failed checks honestly. Each new head requires fresh external review before merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,10 @@ Report vulnerabilities privately through [SECURITY.md](SECURITY.md).
 
 Follow [delivery workflow](docs/delivery.md) for issue scope, board transitions,
 PR linkage and completion evidence. The project board is the live work queue.
+
+## Agent framework references and checkpoints
+
+Use [framework guidance](docs/framework-agent-guidance.md) for installed-version
+Next.js documentation and the official FastAPI skill. Follow AGENTS.md for small
+coherent commits and regular verified pushes within the authorized task. Review
+these references when upgrading dependencies; preserve local architectural rules.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -25,3 +25,9 @@ is GBP-only. Preserve the partial PUT contract and reject null required fields.
 See docs/decisions/0001-product-money.md from the repository root for the decision.
 Dependency updates must pass make requirements-check and make audit. CI enforces
 an 85% coverage minimum; tests are not a substitute for PostgreSQL migration checks.
+
+Before FastAPI changes, read the official skill bundled with the installed
+FastAPI package and its relevant references. See
+[framework guidance](../docs/framework-agent-guidance.md) for a portable lookup.
+Preserve our SQLAlchemy 2, Decimal, authentication and migration conventions;
+upstream tooling preferences do not authorize architectural migrations.

--- a/docs/framework-agent-guidance.md
+++ b/docs/framework-agent-guidance.md
@@ -1,0 +1,60 @@
+# Framework guidance for coding agents
+
+Repository instructions are stored in Git so agents can discover them in any
+checkout. AGENTS.md defines working rules, scoped AGENTS.md files route framework
+work, and .agents/skills contains repeatable workflows. The Wiki explains these
+rules and should link here instead of duplicating them.
+
+## Next.js
+
+Follow the [official AI coding agent guide](https://nextjs.org/docs/app/guides/ai-agents).
+After installing the locked frontend dependencies, read the relevant files under
+`frontend/node_modules/next/dist/docs/`. They match the installed Next.js version.
+Use local documentation before assuming an API from memory or newer online docs.
+If missing, restore locked dependencies first; otherwise consult official docs
+for the installed version and state any remaining version uncertainty.
+
+For runtime changes, inspect compilation errors, browser console and network
+failures and the actual rendered page. Use the existing development server when
+appropriate; check its port/process before starting another. The Next.js dev
+server exposes framework diagnostics through `/_next/mcp` when supported; browser
+verification complements these diagnostics. Use available runtime tools rather
+than requiring a particular editor or silently installing global integrations.
+Follow documented error remedies and retain production CI and browser regression
+checks. Do not enable caching or other architectural features merely because a
+generic guide demonstrates them.
+
+## FastAPI
+
+Use the [official FastAPI skill](https://github.com/fastapi/fastapi/blob/master/fastapi/.agents/skills/fastapi/SKILL.md).
+Prefer the copy shipped with the locked installed package over the moving master
+branch. From the repository root, locate it without hard-coding a Python version
+or a developer's home directory:
+
+```sh
+backend/.venv/bin/python -c 'import pathlib, fastapi; print(pathlib.Path(fastapi.__file__).parent / ".agents/skills/fastapi/SKILL.md")'
+```
+
+Read that file and resolve its reference links relative to its containing folder.
+The existing ecommerce-backend skill routes agents to it; no machine-specific
+symlink, copied upstream skill or global installation is required. In another
+virtual environment, substitute that environment's Python interpreter.
+If the package does not include the skill, use the official documentation matched
+to the installed release; do not upgrade dependencies solely to obtain a skill.
+
+Use compatible dependency injection, Pydantic validation, response filtering and
+sync/async patterns. Our SQLAlchemy 2 persistence, Decimal money, authorization,
+transaction boundaries and migration rules remain in force. An upstream preference
+for SQLModel or another tool is not approval to replace working architecture.
+
+## Maintenance and delivery
+
+When upgrading a framework, inspect changes to its bundled guidance along with
+release notes and rerun relevant checks. Keep upstream reference content upstream;
+commit our routing instructions, project decisions and workflow rules here.
+
+Make small coherent commits with clear Conventional Commit messages. Keep each
+behavior and its necessary tests together; generated files may make a legitimate
+commit larger. After relevant checks and staged-diff review, push verified
+milestones regularly within the user's existing authorization. Do not force-push
+or weaken CI to meet this cadence. Re-request current-head review after changes.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -29,3 +29,8 @@ Use Tailwind semantic tokens and shadcn primitives for new UI. Read
 [design-system.md](design-system.md) before adding components or changing global
 CSS. Preserve the documented reset strategy and server/client boundaries.
 Use lucide-react for UI icons; do not create custom SVG artwork.
+
+Before Next.js changes, read relevant version-matched guides under
+`node_modules/next/dist/docs/` from this frontend directory. Inspect runtime
+errors and verify affected pages in the browser; use documented fixes. See
+[framework guidance](../docs/framework-agent-guidance.md) for discovery and fallback.


### PR DESCRIPTION
## Summary
Persist installed-version Next.js and FastAPI guidance in repository instructions, preserving this project's architecture. Define small coherent commits and regular verified pushes so the workflow survives new agents and sessions.

## Issue
Closes #82

## Acceptance criteria
- [x] Scoped instructions point to bundled framework guidance with a portable FastAPI lookup.
- [x] Existing backend and PR skills route to canonical project rules.
- [x] Small commits and regular pushes retain CI, authorization and fresh-review requirements.
- [x] A canonical reference documents runtime verification, fallbacks and maintenance.

## Testing
Documentation-only self-review; git diff --check passes. Confirmed the installed Next.js documentation directory and FastAPI 0.141.1 skill exist in the configured application environment. Relative repository links were checked against their target paths. No runtime code or dependencies changed. Wiki publication follows merge and will link to the canonical guide.

## Review
Self-review performed. External Codex review and CI pending for this commit. Owner: @youneshenniwrites.
