### PR TITLE
docs: persist ticket slicing and fresh-context handoffs

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -7,6 +7,8 @@ Read [delivery rules](../../../docs/delivery.md), the [PR template](../../../.gi
 
 Inspect the working tree, intended base, full diff, linked issue and existing PRs before writing. Reuse an existing PR for this branch instead of creating a duplicate. Preserve unrelated work and real contributor authorship. Reuse or create a scoped issue under the user's delivery authorization.
 
+Check the issue against the canonical ticket boundaries in the delivery rules linked above. If the diff materially expands the outcome, refine its scope before opening the PR; retain necessary tests and safeguards in the same viable slice. Refresh the issue handoff with the PR and actual verification state.
+
 Use [self-review](../self-review/SKILL.md) before requesting external review. Fill the canonical template from the final implementation: factual acceptance checkboxes, tests actually run, limitations and disclosed self-review. Use Closes only for a fully completed issue; otherwise Refs. Remove irrelevant optional sections and Jira placeholders.
 
 Within existing push/PR authorization, commit and push the intended changes, then create or refresh the PR using gh/API. Pass multiline text through a body file or structured JSON, never shell interpolation of PR content. Apply the ownership helper and read back title, base/head, body, owner assignment and labels. Request only Codex using the current-head protocol in [review documentation](../../../docs/codex-review.md); avoid duplicate requests for an unchanged head.

--- a/.agents/skills/refine-tickets/SKILL.md
+++ b/.agents/skills/refine-tickets/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: refine-tickets
+description: Split broad ecommerce work into independently testable stories and persist scope and handoff before implementation.
+---
+
+Read root AGENTS.md, [delivery policy](../../../docs/delivery.md), relevant scoped
+guidance and the parent issue. Inspect existing issues and PRs with pagination
+before creating duplicates. Use the canonical hierarchy, scope checklist and
+review-size guidance there; do not maintain a second copy of those rules here.
+
+Within the owner's planning authorization, propose or update linked child stories
+with outcomes, dependencies, exclusions, acceptance criteria and validation.
+Separate independently deliverable architectural prerequisites before coding;
+keep each behavior's required tests, security and recovery together. Preserve
+existing ownership, links and implementation evidence. Do not close a parent
+merely because it has been split or one child has merged.
+
+Record the next unblocked story and a compact handoff in the issue. Use
+[update-delivery-board](../update-delivery-board/SKILL.md) for actual statuses,
+not invented workflow columns. Read back changed issues and links. Refinement
+does not authorize implementation, parallel work, merge or deployment.

--- a/.agents/skills/refine-tickets/agents/openai.yaml
+++ b/.agents/skills/refine-tickets/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Refine tickets"
+  short_description: "Split broad work into reviewable stories"
+  default_prompt: "Use $refine-tickets to scope the current ecommerce backlog item before implementation."

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,0 +1,44 @@
+name: Scoped story or epic
+description: Define one testable outcome, or a parent outcome to refine before coding.
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Work category
+      options:
+        - Story
+        - Epic
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome and scope
+      description: Describe the outcome, included behavior and explicit exclusions. Follow docs/delivery.md; refine epics into linked stories before implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Parent, children and dependencies
+      description: Link related issues and blockers, or state none. Subtasks can be a checklist; they do not replace story acceptance criteria.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria and validation
+      description: Testable outcomes with necessary security, error recovery, tests and documentation. Explain any substantial indivisible review scope.
+    validations:
+      required: true
+  - type: textarea
+    id: handoff
+    attributes:
+      label: Handoff
+      description: Keep current when pausing or transferring work; verify evidence on resume.
+      value: |
+        - Implementing PR/branch: not started
+        - Completed: none
+        - Remaining/blockers:
+        - Tested revision and results: not tested
+        - Next action:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,8 @@ What changed and why—in 1–3 sentences.
 ## Issue
 Closes #<!-- actual issue number; use Refs #N for partial work -->
 
+<!-- State the single outcome and important exclusions; link parent/dependencies and the issue handoff. If scope grew substantially, explain the split or why this PR remains coherent. See docs/delivery.md. -->
+
 ## Before / After
 <!-- Optional: include for meaningful behaviour changes; add screenshots if useful. -->
 | Before | After |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,16 @@ are implemented; checkout is planned. Read
 docs/plans/portfolio.md, docs/architecture.md, and docs/plans/roadmap.md before choosing work; update their
 factual status when a feature lands.
 
+## Start here in every new session
+
+Read [delivery policy](docs/delivery.md#starting-without-conversation-history),
+the assigned issue and its current handoff before editing. Refine broad work with
+[refine-tickets](.agents/skills/refine-tickets/SKILL.md); follow the canonical
+[ticket boundaries](docs/delivery.md#ticket-hierarchy-and-review-scope).
+Read scoped AGENTS.md files and [framework guidance](docs/framework-agent-guidance.md)
+for installed-version Next.js/FastAPI references. Conversation history is optional;
+verify current task state in Git and GitHub rather than assuming a handoff is fresh.
+
 ## Commands
 
 - `make setup`: preserve or create local credentials and install locked dependencies.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,5 +1,8 @@
 # Backend conventions
 
+Read root [AGENTS.md](../AGENTS.md) and the assigned issue's scope/handoff first;
+[delivery policy](../docs/delivery.md) governs ticket splitting and resume steps.
+
 Routes in app/api/v1 handle HTTP parsing and responses. Authentication dependencies
 live in app/api/deps.py. As commerce grows, domain services coordinate business
 transactions and CRUD helpers perform database operations. Provider adapters handle

--- a/docs/delivery-skills.md
+++ b/docs/delivery-skills.md
@@ -6,6 +6,7 @@ create a background service or replace external Codex review.
 
 | Invoke | Outcome |
 | --- | --- |
+| `$refine-tickets` | Scoped linked stories, dependencies and a resumable issue handoff before coding. |
 | `$create-pr` | Issue-linked PR with factual description, ownership, labels and review request. |
 | `$self-review PR #42` | Full diff review, findings and verification; review-only requests do not edit code. |
 | `$address-codex-comments PR #42` | Verified fixes, evidence replies, resolved addressed threads and fresh review when needed. |

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -15,10 +15,66 @@ Read the relevant agent guidance and skills, inspect working-tree and PR state,
 and choose a Conventional Commit branch. Prefer gh/API and Git; use browser UI
 only for capabilities unavailable through those interfaces.
 
+## Ticket hierarchy and review scope
+
+Use an **epic** issue for a larger outcome and link its child **story** issues
+with GitHub sub-issues when available, otherwise explicit parent/child links.
+A story delivers one independently testable behavior, normally in one PR.
+Implementation **subtasks** are a checklist inside that story; create a linked
+issue only when separate ownership or delivery is useful. A **bug** issue records
+reproduction, expected/observed behavior and regression evidence. These are work
+categories, not additional board statuses or a requirement for custom labels.
+
+Before coding, record the story's outcome, parent (if any), included behavior,
+exclusions, acceptance criteria, dependencies and validation. Split substantial
+architectural prerequisites before implementation; keep their interfaces stable
+so later stories can build on merged work. Prefer a usable vertical slice over
+separate tickets for arbitrary files or technical layers. A standalone foundation
+is appropriate only with a bounded contract and meaningful verification.
+
+Keep necessary authorization, data integrity, error recovery, tests and contract
+documentation inside each viable slice. They are not optional later polish.
+For example, an add-to-cart story includes ownership checks, stock rejection and
+repeat-click behavior; quantity editing can follow as a separate tested story.
+An epic is complete only when its required child outcomes are delivered; merging
+one child PR does not close the parent.
+
+Aim for roughly 200–400 meaningful changed lines per PR; above about 500, reassess
+scope and record the split or explain why the coherent change should stay together.
+Exclude generated outputs and lockfiles from this planning signal. This is not a
+CI limit: do not omit tests, conceal changes or create broken intermediate slices
+to satisfy a number. Small commits do not make an oversized PR easy to review.
+If new findings substantially expand scope, update the issue and split independent
+follow-ups before adding more work. Defects required for the active acceptance
+criteria remain in scope; follow existing approval rules for any deferral.
+
+## Starting without conversation history
+
+1. Open the actual repository and read root AGENTS.md, this policy, and the assigned
+   issue with its latest handoff. Inspect local changes, base/head and open PRs.
+2. Read scoped AGENTS.md files and applicable skills. For framework changes use
+   [framework guidance](framework-agent-guidance.md) to locate installed-version
+   Next.js documentation or the official FastAPI skill; retain local architecture
+   and security decisions rather than copying generic examples.
+3. Verify ticket boundaries and dependencies before editing. Use
+   [refine-tickets](../.agents/skills/refine-tickets/SKILL.md) for broad work.
+   Missing permission or contradictory scope requires clarification; a missing
+   history transcript does not require reconstructing earlier conversations.
+
+AGENTS.md is the repository entry point, versioned docs own policy, skills own
+repeatable procedures, and issues/PRs own current delivery evidence. The Wiki links
+to these sources for explanation. Do not duplicate policy in every file or copy
+moving upstream documentation into the repository. Some tools do not discover
+AGENTS.md or skills automatically: configure their supported instruction entry
+point to read AGENTS.md, or explicitly include that instruction when starting.
+Never claim a fresh agent has loaded guidance without checking its discovery path.
+
 ## Board and PR lifecycle
 
 - Backlog: planned work; start only when scoped and unblocked.
-- In progress: implementation underway; keep one implementation ticket active.
+- In progress: implementation underway; keep one implementation ticket active by default.
+  Explicit owner-authorized parallel work uses isolated worktrees, records each
+  ticket's scope and overlaps, and isolates any running services.
 - In review: a PR is open and review/checks are underway.
 - Done: acceptance criteria are met and implementing PRs are merged.
 
@@ -46,7 +102,13 @@ After merge, verify issue closure, update board status, record
 evidence and identify the next unblocked Backlog ticket. Check README, design notes,
 roadmap, Wiki and skills for changes relevant to the delivered behavior.
 
-At handoff, report merged/open PRs, remaining blockers, checks and the next ticket.
+At handoff, update a compact section in the active issue (link PR evidence rather
+than duplicating logs): implementing PR/branch, completed work, remaining work and
+blockers, tested revision and results, and the next concrete action. Distinguish
+local, pushed, merged and deployed states. Refresh it when pausing, transferring
+work or changing scope; verify it against Git and GitHub when resuming. Do not
+store secrets, transcripts or machine-specific temporary paths in the handoff.
+Report merged/open PRs, remaining blockers, checks and the next ticket.
 Inspect open maintenance PRs and either resolve them within authorized scope or
 record their next action; do not silently leave failures unexplained. This is an
 agent workflow, not a continuously running service. Scheduled dependency review

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,5 +1,8 @@
 # Frontend agent guidance
 
+Read root [AGENTS.md](../AGENTS.md) and the assigned issue's scope/handoff first;
+[delivery policy](../docs/delivery.md) governs ticket splitting and resume steps.
+
 This is the runnable Next.js App Router/TypeScript catalog. Read the root portfolio
 plan and naming skill. Use Node 24.20.0 (.nvmrc) and npm 11.19.1; commit package-lock.json.
 


### PR DESCRIPTION
## Summary
New sessions currently depend on scattered guidance and chat context to understand how to split work. Root and scoped agent instructions now route to one delivery policy defining small testable stories, review-scope checks and compact issue handoffs, with a refinement skill and issue/PR prompts.

## Issue
Closes #85. This is the workflow prerequisite for #84; its audit and #67's broader PR-template cleanup remain separate. No application behavior or PR #80 changes.

## Acceptance criteria
- [x] Define epic/story/subtask/bug boundaries and retain required safeguards and tests within each viable slice.
- [x] Route fresh sessions to canonical delivery policy and existing installed-version Next.js/FastAPI guidance.
- [x] Provide refinement, story/epic and PR prompts for scope, dependencies, exclusions and handoff state.
- [x] Validate local discovery paths, templates and skill metadata; disclose self-review.

## Testing
- Checks run: local Markdown link resolution (29 links), YAML parsing, unique issue-form field IDs, skill frontmatter and picker metadata validation, `git diff --check`.
- Results and tested commit: all passed for `9fcd667`; docs/templates only.
- Fresh-context walkthrough: starting at AGENTS.md reaches delivery scope policy, the assigned issue handoff and refinement skill; scoped frontend/backend instructions reach the existing version-matched framework guidance. This was a static self-review, not an independent AI-session experiment.
- Not tested / limitations: application tests not rerun because runtime code is unchanged. GitHub's rendered issue form and another tool's automatic AGENTS.md discovery were not exercised. Wiki pointer publication follows merge; no unmerged policy was published as delivered.

## Review
- Implementation review: self-review of the complete diff against main `017358f`; no outstanding findings identified.
- Owner: @youneshenniwrites
- External reviewer: Codex Code Review
- [ ] External review completed for the latest commit
- [ ] Review findings addressed
- [ ] Required CI checks passed
- [ ] Current-head external review verified, or explicit owner-approved deferral linked
