### PR TITLE
ci: upgrade artifact uploads to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-coverage
           path: backend/coverage.xml

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -30,7 +30,7 @@ jobs:
         run: uv run pip-audit --strict --format json --output dependency-audit.json
       - name: Upload audit report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dependency-audit
           path: backend/dependency-audit.json
@@ -53,7 +53,7 @@ jobs:
         run: npm audit --json > audit.json
       - name: Upload audit results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-dependency-audit
           path: frontend/audit.json

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -53,7 +53,7 @@ jobs:
         run: npm audit
       - name: Upload frontend unit coverage
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-unit-coverage
           path: frontend/coverage
@@ -95,7 +95,7 @@ jobs:
         run: npm run test:e2e
       - name: Upload browser report, screenshots and failure traces
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-browser-evidence
           path: |
@@ -105,7 +105,7 @@ jobs:
       - name: Package the standalone build
         run: tar -czf storefront-build.tar.gz -C .next/standalone .
       - name: Upload validated storefront build
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: storefront-build
           path: frontend/storefront-build.tar.gz


### PR DESCRIPTION
## Summary
Upgrade all six artifact uploads from the Node 20 v4 pin to the verified immutable v7.0.1 commit, whose action metadata declares Node 24. Coverage, audit reports, browser evidence and the standalone build retain their existing names, paths, retention, conditions and zipped format.

## Issue
Closes #76

## Acceptance criteria
- [x] Inventory all artifact actions and review official supported releases and compatibility.
- [x] Pin the verified upstream v7.0.1 commit `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`.
- [x] Verify all six uploads and downloaded archive contents in this PR's CI.
- [x] Required CI and fresh external review pass.
- [x] No warning suppression or insecure runtime opt-in.

## Testing
- `git diff --check` passed.
- Local invariant check passed: exactly six pins changed and every other workflow byte is identical to base `789cf4e`.
- Reproduced the original Node 20 warning through run 34597847215's check annotations.
- Inspected upstream [v6 runtime/runner requirements](https://github.com/actions/upload-artifact/releases/tag/v6.0.0), [v7 changes](https://github.com/actions/upload-artifact/releases/tag/v7.0.0), [v7.0.1 release](https://github.com/actions/upload-artifact/releases/tag/v7.0.1), and pinned action metadata (`runs.using: node24`, `archive: true`). GitHub-hosted `ubuntu-latest` satisfies the minimum runner 2.327.1; there are no self-hosted runners.
- Deployment inspection: no `download-artifact` actions exist. Production delivery uses `git archive` of the verified revision and Vercel source deployment; no downstream artifact download is required and no deployment was run.
- Hosted CI passed at `74ef0943b93a6f7bd6f05d24ba8965997b39e0a1`: [Backend CI](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34713722692), [Frontend CI](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34713722661) (37 browser tests), [Dependency audit](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34713722666), and [Review gate tests](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34713722648).
- All six artifacts downloaded with `gh run download`: both audit JSON files parsed; backend coverage XML parsed; frontend LCOV and HTML present; Playwright report HTML present; standalone tar.gz readable with 1,646 entries including server.js. All five upload jobs have empty check annotations: the prior Node 20 warning is gone. Actual hosted runner version: 2.337.0.
- [Clean Codex review](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/90#issuecomment-5648127444) and completed trusted-bot summary match this head; no review threads exist. [Fresh review gate](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34713885810) reports success.
- PR remains open for coordinated merge; no deployment performed.

## Review
- Implementation self-review and history-informed preflight completed over the entire six-line diff; no findings. Checked artifact contracts, always-run report uploads, immutable pin provenance, runner compatibility, workflow permissions and production/review trust boundaries.
- Owner: @youneshenniwrites
- External reviewer: Codex Code Review
- [x] External review completed for the latest commit
- [x] Review findings addressed
- [x] Required CI checks passed
- [x] Current-head external review verified
