### PR TITLE
fix(ci): recognize observed Codex clean-review wording

### DIFF
--- a/.agents/skills/preflight-review/references/lessons.md
+++ b/.agents/skills/preflight-review/references/lessons.md
@@ -13,7 +13,7 @@ remove an old contradictory instruction. Verify local launch URLs against exact
 origin checks. Preserve self-review disclosure and distinguish informational
 review status from enforced approval.
 
-## Review automation trust — PR 37
+## Review automation trust — PRs 37, 93
 
 Check who can create authoritative requests, exact request syntax and verified
 bot identity. Trace submitted, edited and dismissed findings after a clean signal;
@@ -21,6 +21,11 @@ resolving or dismissing a finding does not create new approval. Check failed or
 late refreshes, reopened PRs and multiple PRs sharing a SHA. A commit status is not
 inherently PR-bound. Respect the explicit deferred enforcement work in #38; do not
 claim the historical inherited-status finding has been eliminated.
+
+When adapting clean-result wording, match the complete observed message and known
+footer; a trusted prefix plus a commit anywhere in the body can admit contradictory
+prose. Preserve actual protocol fixtures and reject inserted/trailing findings
+([PR #93](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/93#discussion_r3997324325)).
 
 ## UI lifecycle and accessibility — PRs 56, 66, 78
 

--- a/scripts/codex_review_gate.py
+++ b/scripts/codex_review_gate.py
@@ -47,6 +47,34 @@ def review_request(comment):
     )
 
 
+# Observed integration footer; accept whitespace variation, not additional prose.
+CLEAN_RESULT_FOOTER = """
+<details> <summary>ℹ️ About Codex in GitHub</summary>
+<br/>
+[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general).
+Reviews are triggered when you
+- Open a pull request for review
+- Mark a draft as ready
+- Comment "@codex review".
+If Codex has suggestions, it will comment; otherwise it will react with 👍.
+Codex can also answer questions or update the PR. Try commenting "@codex address that feedback".
+</details>
+"""
+
+
+def clean_result(body, sha):
+    """Match the complete observed result, optionally followed by its known footer."""
+    normalized = " ".join(body.split())
+    for signoff in ("Can't wait for the next one!", "Swish!"):
+        result = (
+            f"Codex Review: Didn't find any major issues. {signoff} "
+            f"**Reviewed commit:** `{sha[:10]}`"
+        )
+        if normalized in (result, result + " " + " ".join(CLEAN_RESULT_FOOTER.split())):
+            return True
+    return False
+
+
 def evaluate(sha, comments, reactions, unresolved, reviews=()):
     if unresolved:
         return "pending", "Resolve review conversations and obtain a clean re-review"
@@ -92,16 +120,7 @@ def evaluate(sha, comments, reactions, unresolved, reviews=()):
         if trusted(c)
         and c.get("created_at", "") >= request["created_at"]
         and c.get("updated_at") == c.get("created_at")
-        and c.get("body", "").startswith(
-            (
-                "Codex Review: Didn't find any major issues. Can't wait for the next one!\n\n",
-                "Codex Review: Didn't find any major issues. Swish!\n\n",
-            )
-        )
-        and re.search(
-            r"\*\*Reviewed commit:\*\* `" + re.escape(sha[:10]) + r"`(?:\n|$)",
-            c["body"],
-        )
+        and clean_result(c.get("body", ""), sha)
     ]
     positive = marker in request["body"] and any(
         trusted(r) and r.get("content") == "+1"

--- a/scripts/codex_review_gate.py
+++ b/scripts/codex_review_gate.py
@@ -93,7 +93,10 @@ def evaluate(sha, comments, reactions, unresolved, reviews=()):
         and c.get("created_at", "") >= request["created_at"]
         and c.get("updated_at") == c.get("created_at")
         and c.get("body", "").startswith(
-            "Codex Review: Didn't find any major issues. Can't wait for the next one!\n\n"
+            (
+                "Codex Review: Didn't find any major issues. Can't wait for the next one!\n\n",
+                "Codex Review: Didn't find any major issues. Swish!\n\n",
+            )
         )
         and re.search(
             r"\*\*Reviewed commit:\*\* `" + re.escape(sha[:10]) + r"`(?:\n|$)",

--- a/scripts/tests/fixtures/codex-clean-swish.txt
+++ b/scripts/tests/fixtures/codex-clean-swish.txt
@@ -1,0 +1,20 @@
+Codex Review: Didn't find any major issues. Swish!
+
+**Reviewed commit:** `59fbb6437d`
+
+<details> <summary>ℹ️ About Codex in GitHub</summary>
+<br/>
+
+[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you
+- Open a pull request for review
+- Mark a draft as ready
+- Comment "@codex review".
+
+If Codex has suggestions, it will comment; otherwise it will react with 👍.
+
+
+
+
+Codex can also answer questions or update the PR. Try commenting "@codex address that feedback".
+            
+</details>

--- a/scripts/tests/fixtures/codex-clean-swish.txt
+++ b/scripts/tests/fixtures/codex-clean-swish.txt
@@ -16,5 +16,5 @@ If Codex has suggestions, it will comment; otherwise it will react with 👍.
 
 
 Codex can also answer questions or update the PR. Try commenting "@codex address that feedback".
-            
+
 </details>

--- a/scripts/tests/test_codex_review_gate.py
+++ b/scripts/tests/test_codex_review_gate.py
@@ -258,3 +258,71 @@ class EditedReviews(unittest.TestCase):
             )[0],
             "success",
         )
+
+
+class SwishCleanEvidence(ReviewEvidence, EditedReviews):
+    """Replay all clean-result trust checks with the observed PR #91 wording."""
+
+    def clean_comment(self):
+        comment = super().clean_comment()
+        comment["body"] = comment["body"].replace(
+            "Can't wait for the next one!", "Swish!"
+        )
+        return comment
+
+    def test_unrecognized_clean_wording_stays_pending(self):
+        for suffix in (
+            "Swish! But there are issues.",
+            "Swish?",
+            "Everything looks fine!",
+            "",
+        ):
+            with self.subTest(suffix=suffix):
+                comment = self.clean_comment()
+                comment["body"] = comment["body"].replace("Swish!", suffix)
+                self.assertEqual(
+                    evaluate(
+                        self.sha, [self.request, self.summary, comment], {}, False
+                    )[0],
+                    "pending",
+                )
+
+    def test_edited_clean_comment_stays_pending(self):
+        comment = self.clean_comment()
+        comment["updated_at"] = "2026-09-08T10:02:00Z"
+        self.assertEqual(
+            evaluate(self.sha, [self.request, self.summary, comment], {}, False)[0],
+            "pending",
+        )
+
+    def test_stale_clean_comment_stays_pending(self):
+        comment = self.clean_comment()
+        comment["created_at"] = comment["updated_at"] = "2026-09-08T09:59:00Z"
+        self.assertEqual(
+            evaluate(self.sha, [self.request, self.summary, comment], {}, False)[0],
+            "pending",
+        )
+
+    def test_clean_wording_does_not_replace_required_evidence(self):
+        cases = (
+            ("request", "updated_at", "2026-09-08T10:02:00Z"),
+            ("request", "author_association", "NONE"),
+            ("summary", "body", "Unexpected summary"),
+            ("summary", "updated_at", "2026-09-08T09:59:00Z"),
+        )
+        for target, key, value in cases:
+            with self.subTest(target=target, key=key):
+                request, summary = dict(self.request), dict(self.summary)
+                (request if target == "request" else summary)[key] = value
+                self.assertEqual(
+                    evaluate(
+                        self.sha, [request, summary, self.clean_comment()], {}, False
+                    )[0],
+                    "pending",
+                )
+        self.assertEqual(
+            evaluate(
+                self.sha, [self.request, self.summary, self.clean_comment()], {}, True
+            )[0],
+            "pending",
+        )

--- a/scripts/tests/test_codex_review_gate.py
+++ b/scripts/tests/test_codex_review_gate.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import unittest
 from unittest.mock import patch
 
@@ -326,3 +327,34 @@ class SwishCleanEvidence(ReviewEvidence, EditedReviews):
             )[0],
             "pending",
         )
+
+
+    def test_observed_full_comment(self):
+        comment = self.clean_comment()
+        comment["body"] = (
+            Path(__file__).with_name("fixtures") / "codex-clean-swish.txt"
+        ).read_text().replace("59fbb6437d", self.sha[:10])
+        self.assertEqual(
+            evaluate(self.sha, [self.request, self.summary, comment], {}, False)[0],
+            "success",
+        )
+
+    def test_inserted_or_trailing_prose_stays_pending(self):
+        for body in (
+            self.clean_comment()["body"].replace(
+                "**Reviewed commit:**", "But I found a blocking issue\n\n**Reviewed commit:**"
+            ),
+            self.clean_comment()["body"] + "But I found a blocking issue",
+            (Path(__file__).with_name("fixtures") / "codex-clean-swish.txt")
+            .read_text()
+            .replace("59fbb6437d", self.sha[:10])
+            .replace("</details>", "But I found a blocking issue</details>"),
+        ):
+            with self.subTest(body=body):
+                comment = dict(self.clean_comment(), body=body)
+                self.assertEqual(
+                    evaluate(
+                        self.sha, [self.request, self.summary, comment], {}, False
+                    )[0],
+                    "pending",
+                )


### PR DESCRIPTION
## Summary
PR #91 received a verified clean Codex review ending in “Swish!”, but the adapter recognized only the previous exact sign-off and left its status pending. Recognize both observed sign-offs by comparing the complete message and optional known integration footer. Identity, commit, freshness, summary and findings checks remain required; unknown or contradictory prose stays pending.

## Issue
Closes #92
Unblocks #91. Broader review enforcement remains tracked in #38.

## Acceptance criteria
- [x] Recognize the observed wording while validating the complete known result.
- [x] Preserve all existing trust and freshness checks.
- [x] Reproduce the failure and add positive and negative regressions.
- [x] Required CI and fresh current-head Codex review pass.

## Testing
- Regression failed before the fix: `SwishCleanEvidence.test_explicit_clean_comment` returned pending instead of success.
- `python3 -m unittest discover -s scripts/tests -q`: 70 tests passed, including the existing clean-result and edited-review tests replayed with the new wording, plus unknown/inserted/trailing prose, changed-footer content, edited/stale comments, required evidence, and unresolved-thread rejection. The actual PR #91 message is retained as a whitespace-normalized fixture.
- `python3 -m unittest discover -s scripts -p 'test_production_ready.py' -q`: 7 tests passed (mocked delivery operations only).
- `git diff --check`: passed.
- Read-only live `inspect` against #91 at `59fbb6437d926600f7c3ac9d9365bf2c950bd596` returned success with the updated adapter. No status was published and no PR code ran with write permissions.
- Tested revision: `1a13ec1971188c88bbbe604bbca8a992c451bf97`. [Backend CI](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34714897660), [Frontend CI](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34714897670), [audits](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34714897663), and [review tests](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34714897665) all passed.
- Fresh trusted-bot [clean review](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/93#issuecomment-5648252480) and completed summary match this exact head; comment is unedited and zero threads are unresolved. The bot used another unrecognized sign-off, “Another round soon, please!”, so the informational status stays pending. Coordinating disposition before merge; no success status was forged.

## Review
- Implementation self-review and history-informed preflight completed against base `068efa9`; Codex P2 addressed and regression-tested: prefix-only matching admitted contradictory prose before/after the commit. Complete-message comparison now rejects it, and the thread is resolved with evidence. Reviewed complete diff and the PR #37 trust lessons: trusted bot, current commit, unedited request/result, fresh completed summary, unresolved conversations and later/edited findings remain required. The legacy clean phrase remains supported; no arbitrary-prose wildcard added. Added the complete-message invariant to preflight lessons.
- Owner: @youneshenniwrites
- External reviewer: Codex Code Review
- [x] External review completed for the latest commit
- [x] Review findings addressed
- [x] Required CI checks passed
- [ ] Current-head external review verified
