### PR TITLE
docs: simplify PR descriptions and delivery guidance

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -9,7 +9,7 @@ Inspect the working tree, intended base, full diff, linked issue and existing PR
 
 Check the issue against the canonical ticket boundaries in the delivery rules linked above. If the diff materially expands the outcome, refine its scope before opening the PR; retain necessary tests and safeguards in the same viable slice. Refresh the issue handoff with the PR and actual verification state.
 
-Use [self-review](../self-review/SKILL.md) before requesting external review. Fill the canonical template from the final implementation: factual acceptance checkboxes, tests actually run, limitations and disclosed self-review. Use Closes only for a fully completed issue; otherwise Refs. Remove irrelevant optional sections and Jira placeholders.
+Use [self-review](../self-review/SKILL.md) before requesting external review. Fill the canonical template from the final implementation: a short customer or contributor outcome, linked issue, factual acceptance criteria, tests actually run and relevant limitations. Keep self-review disclosure brief and link current-head external review and CI evidence with their actual state; pending or failed checks must not be described as passed. Keep assignment in the sidebar rather than repeating owner/reviewer metadata or review checkboxes. Use Closes only for a fully completed issue; otherwise Refs. Remove irrelevant optional sections and Jira placeholders.
 
 Before requesting external review, complete [preflight-review](../preflight-review/SKILL.md)
 and record actual evidence; it does not replace independent Codex review.

--- a/.agents/skills/ecommerce-pr-ownership/SKILL.md
+++ b/.agents/skills/ecommerce-pr-ownership/SKILL.md
@@ -13,9 +13,13 @@ Existing bot/contributor PRs retain their real authors.
 
 Use .github/pull_request_template.md as the canonical description structure:
 Summary, Issue, optional Before / After, Acceptance criteria, Testing, Review,
-and optional Deployment / Compatibility. Fill it with actual evidence; remove
-unused optional sections. Link real issues and never pre-check unverified review
-or test claims. Use this structure when maintaining bot PRs, preserving useful
+and optional Deployment notes. Lead with the customer or contributor outcome,
+use acceptance criteria from the issue, and report the tested commit and results.
+Keep Review to a brief self-review disclosure and links to current-head external
+review and CI evidence, explicitly noting pending or failed results. Remove
+unused optional sections. Keep owner assignment and labels in the sidebar; do
+not duplicate them or add review checkboxes to the body. Link real issues and
+never claim unverified review or test success. Use this structure when maintaining bot PRs, preserving useful
 upstream release information.
 
 After creating a PR, choose labels that describe its actual scope: bug,

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,39 +1,32 @@
-<!-- PR title: type(scope): description. Replace placeholders; remove optional sections when irrelevant. -->
+<!-- PR title: type(scope): description. Replace prompts and remove irrelevant optional sections. -->
 
 ## Summary
-What changed and why—in 1–3 sentences.
+
+Describe the customer or contributor outcome in 1–3 sentences: what changes and why.
 
 ## Issue
+
 Closes #<!-- actual issue number; use Refs #N for partial work -->
 
-<!-- State the single outcome and important exclusions; link parent/dependencies and the issue handoff. If scope grew substantially, explain the split or why this PR remains coherent. See docs/delivery.md. -->
-
 ## Before / After
-<!-- Optional: include for meaningful behaviour changes; add screenshots if useful. -->
-| Before | After |
-| --- | --- |
-| Previous behaviour | New behaviour |
+
+<!-- Optional: show a meaningful behavior change with a short comparison or screenshots. -->
 
 ## Acceptance criteria
-- [ ] Required outcome from the linked issue
-- [ ] Relevant error and edge cases handled
-- [ ] Documentation updated where needed
+
+<!-- Use the linked issue's criteria; check only verified outcomes. -->
+- [ ] Required outcome
 
 ## Testing
-- Checks run:
-- Results and tested commit:
-- Not tested / limitations:
+
+Give the tested commit, checks and results. Note skipped checks and relevant limitations.
 
 ## Review
-- Implementation review: self-review / independent review (identify which)
-- Owner: @youneshenniwrites
-- External reviewer: Codex Code Review
-- [ ] External review completed for the latest commit
-- [ ] Review findings addressed
-- [ ] Required CI checks passed
-- [ ] Current-head external review verified, or explicit owner-approved deferral linked
-<!-- Keep the owner as assignee; request only Codex as reviewer. Trigger Codex review through its integration; naming it here does not request a review. The Codex review status is informational pending #38; verify actual review evidence as described in docs/codex-review.md; a human Approve review is not required. -->
 
-## Deployment / Compatibility
-<!-- Optional: omit if not applicable. -->
-Migrations, configuration changes, breaking changes, or rollback notes.
+Briefly disclose self-review and its outcome. Link the current-head Codex review and CI results, stating pending or failed results honestly; refresh after changes.
+
+<!-- Assignment and labels belong in the sidebar. Follow docs/codex-review.md: required CI and current-head external review still gate merge; the Codex review status is informational pending #38. -->
+
+## Deployment notes
+
+<!-- Optional: include relevant migrations, configuration, compatibility or deployment limitations. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,9 @@ Use the PR template headings and reference the GitHub issue. Use Closes #N
 for completed tickets and Refs #N for partial work. Never invent a ticket reference.
 
 Explain the problem and resulting behavior, then give the commands/results and
-material limitations. Include relevant screenshots for UI changes, or API/test
+material limitations. Keep the Review section to a brief self-review disclosure
+and links to current-head Codex review and CI evidence, stating their actual
+status. Assignment and labels belong in the sidebar. Include relevant screenshots for UI changes, or API/test
 output for backend changes. Do not include tokens, passwords, or customer data.
 
 Review the exact pushed revision. Address actionable findings and rerun affected

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -118,8 +118,13 @@ is not configured. Dependabot proposes updates weekly; it does not review or mer
 
 The [PR template](../.github/pull_request_template.md) defines Summary, Issue,
 optional Before / After, Acceptance criteria, Testing, Review, and optional
-Deployment / Compatibility. Fill acceptance criteria from the issue and testing
-with actual results; remove irrelevant optional sections. No Jira placeholder.
+Deployment notes. Lead with a short customer or contributor outcome; fill
+acceptance criteria from the issue and testing with the tested commit and actual
+results. Use a brief self-review disclosure plus linked current-head Codex review
+and CI evidence. State pending or failed results honestly and refresh evidence
+after changes. Keep owner assignment and labels in the sidebar, without duplicate
+review checkboxes or owner/reviewer metadata in the body. Remove irrelevant
+optional sections. No Jira placeholder.
 
 Assign youneshenniwrites on every PR; do not request them as reviewer.
 Codex is the sole requested reviewer. Request Codex through the review


### PR DESCRIPTION
## Summary

Contributors get a shorter PR template centered on the change, acceptance and evidence. The shared skills and delivery guide now use brief self-review disclosure and linked review/CI results; owner assignment stays in the sidebar.

## Issue

Refs #67

## Acceptance criteria

- [x] Keep the outcome, issue, acceptance, tests and relevant deployment limitations.
- [x] Keep Before / After optional and remove duplicate review checkboxes and sidebar metadata.
- [x] Align creation/ownership skills and delivery guidance without relaxing current-head review or CI requirements.
- [x] Verify this PR as a rendered example.
- [x] Update the Wiki after merge to complete the ticket.

## Testing

On `9a4c2a3`, `git diff --check` passed and every relative Markdown link in the five changed files resolved. A consistency search found no remaining old deployment heading or duplicated reviewer/owner fields in the template, skills or delivery docs. The GitHub-rendered PR description was inspected in Chrome: headings, issue link and acceptance checkboxes render correctly; unused optional sections and duplicate owner/reviewer fields are absent. No application code changed.

## Review

Self-review and history-informed preflight completed; no findings. Checked the complete diff against #67 and the revised #66 description, including preservation of assignment, current-head review, CI and honest pending-state requirements. [GitHub CI](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/94/checks): all required checks passed at `9a4c2a3`, including the [browser rerun](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34715783235). Initial browser run had two catalog image-loading timeouts; 37 tests passed, 2 skipped. Traces showed planter/clock optimizer requests with no response, matching the prior catalog incident. One justified failed-job rerun passed without code or assertion changes; this is not claimed as a fix for the intermittent image-loading issue. [Codex review](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/94#issuecomment-5648347646) is clean for `9a4c2a3`; its unrecognized sign-off leaves the informational status pending (known #38 limitation).

Wiki guidance is published and verified at `f9a8c0e`; #67 acceptance is complete.
