### PR TITLE
ci(coverage): publish readable scoped coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,28 @@ jobs:
       - name: Verify lockfile and requirements consistency
         run: uv run python scripts/check_requirements.py
       - name: Run backend tests and enforce coverage
-        run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml
+        id: coverage_tests
+        run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml --cov-report=html
       - name: Upload coverage report
+        id: coverage_artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-coverage
-          path: backend/coverage.xml
+          path: |
+            backend/coverage.xml
+            backend/htmlcov
+          if-no-files-found: warn
           retention-days: 14
+      - name: Summarize measured backend coverage
+        if: always()
+        env:
+          COVERAGE_OUTCOME: ${{ steps.coverage_tests.outcome }}
+          COVERAGE_ARTIFACT_URL: ${{ steps.coverage_artifact.outputs.artifact-url }}
+        run: >-
+          python ../scripts/coverage_summary.py --kind backend --report coverage.xml
+          --outcome "$COVERAGE_OUTCOME" --artifact-url "$COVERAGE_ARTIFACT_URL"
+          >> "$GITHUB_STEP_SUMMARY"
   container:
     name: Backend · Container build and migration smoke tests
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -48,16 +48,27 @@ jobs:
       - name: Check TypeScript and route types
         run: npm run typecheck
       - name: Run unit tests and enforce coverage
+        id: coverage_tests
         run: npm test
       - name: Audit frontend dependencies
         run: npm audit
       - name: Upload frontend unit coverage
+        id: coverage_artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-unit-coverage
           path: frontend/coverage
           retention-days: 14
+      - name: Summarize measured frontend coverage
+        if: always()
+        env:
+          COVERAGE_OUTCOME: ${{ steps.coverage_tests.outcome }}
+          COVERAGE_ARTIFACT_URL: ${{ steps.coverage_artifact.outputs.artifact-url }}
+        run: >-
+          python3 ../scripts/coverage_summary.py --kind frontend --report coverage/lcov.info
+          --outcome "$COVERAGE_OUTCOME" --artifact-url "$COVERAGE_ARTIFACT_URL"
+          >> "$GITHUB_STEP_SUMMARY"
   browser:
     name: Frontend · Production build and browser tests
     needs: quality

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	cd backend && uv run ruff check . && uv run ruff format --check .
 
 coverage:
-	cd backend && uv run pytest --cov --cov-report=term-missing --cov-report=xml
+	cd backend && uv run pytest --cov --cov-report=term-missing --cov-report=xml --cov-report=html
 
 audit:
 	cd backend && uv run pip-audit --strict

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Coverage and audit artifacts remain available for 14 days. Dependabot proposes
 weekly Python, CI action, and Docker updates; updates still need review and checks.
 CI actions are pinned to commit SHAs. [Tooling details](docs/tooling.md) explain
 coverage scope, local hooks, and how to handle dependency-update failures.
+[Coverage reports](docs/coverage.md) explains Actions summaries, downloadable HTML
+and the deliberately limited frontend measurement.
 
 Static type checking, code scanning, and repository-level required-check rules are
 future tooling increments. We do not claim those controls are enabled today.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,17 +7,20 @@ pinned action SHAs, timeouts and cancellation of superseded runs.
 
 | Workflow / job | Ordered work | Evidence |
 | --- | --- | --- |
-| Backend / Lint, contract and unit tests | Locked install → lint → format → export consistency → tests/coverage | Backend coverage XML |
+| Backend / Lint, contract and unit tests | Locked install → lint → format → export consistency → tests/coverage | Coverage summary, XML and HTML |
 | Backend / PostgreSQL integration tests | Start disposable PostgreSQL → create separate migration DB → full tests | Test logs |
 | Backend / Container build and migration smoke tests | Image build → migrations/startup → HTTP smoke → schema consistency → rollback/reapply | Failure logs |
-| Frontend / Lint, types, contract and unit tests | npm ci → regenerate/check API contract → formatting → lint → types → unit coverage → audit | LCOV coverage |
+| Frontend / Lint, types, contract and unit tests | npm ci → regenerate/check API contract → formatting → lint → types → unit coverage → audit | Scoped coverage summary, LCOV and HTML |
 | Frontend / Production build and browser tests | Production build → disposable real API → desktop/mobile/axe and fault tests → package | Browser report, traces, screenshots, standalone build |
 | Dependency audit / Python and frontend | Audit locked dependencies on PR/push, weekly, or manually | JSON reports |
 
 The frontend browser job depends on its quality job. Backend jobs run independently
-so failures do not hide other evidence. Unit coverage measures catalog/money logic;
+so failures do not hide other evidence. Frontend unit coverage measures only catalog/money and session utilities;
 route rendering, API integration and failure screens are covered by browser tests.
 FastAPI's generated OpenAPI snapshot is checked in CI so API drift fails the PR.
+
+See [coverage reports](coverage.md) for measured scope, unchanged thresholds, report
+links and local reproduction. Missing reports are labelled unavailable, never 0%.
 
 ## Build versus deployment
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,56 @@
+# Reading coverage evidence
+
+Open the backend or frontend quality job's Actions summary. It shows line/branch
+covered and measured counts, percentages, the tested revision, measured scope,
+existing thresholds, test-step outcome and a link to its downloadable report.
+A PR workflow normally tests GitHub's synthetic merge revision (`GITHUB_SHA`),
+not the PR head alone. These summaries do not compare against a base revision.
+
+| Measurement | Included scope | Existing enforced thresholds |
+| --- | --- | --- |
+| Backend | `backend/app`, excluding `app/tests` | coverage.py combined line/branch score ≥85% |
+| Frontend | Only `src/lib/catalog.ts` and `src/lib/session.ts` | Vitest statements ≥95%, branches ≥90%, functions 100%, lines ≥95% |
+
+The frontend percentage is **not coverage of the entire frontend**. Components,
+routes and other utilities are outside this measurement. Backend migration
+subprocesses and frontend browser flows have separate tests; they do not increase
+these coverage percentages. Generated API types and vendor code are outside the
+current frontend include list. Broader meaningful measurement and regression
+comparison are follow-up stories #96 and #97 under #57.
+
+A failed test/coverage step remains failed even when a valid report is available.
+The summary is supporting evidence, not a replacement gate or proof of test quality.
+Missing/malformed reports are explicitly unavailable and fail the reporting step;
+zero measured branches display N/A, not 100%. Artifact-upload failures are visible
+in their own step. Reports expire after 14 days.
+
+Download and extract `backend-coverage` to open `htmlcov/index.html` or inspect
+`coverage.xml`. Download `frontend-unit-coverage` to open `lcov-report/index.html`
+or inspect `lcov.info`. Artifact links require access to the repository/run.
+
+## Reproduce locally
+
+Use the locked runtimes/dependencies described in the development guide:
+
+```sh
+make coverage
+cd frontend
+npm test
+cd ..
+python3 scripts/coverage_summary.py --kind backend --report backend/coverage.xml --outcome success
+python3 scripts/coverage_summary.py --kind frontend --report frontend/coverage/lcov.info --outcome success
+```
+
+Pass the actual test outcome (`failure` when the preceding test command failed).
+Local summaries label the revision `local` and have no artifact link. HTML reports
+are generated in `backend/htmlcov` and `frontend/coverage/lcov-report`.
+
+Reporting runs in existing read-only PR jobs, including forks. It writes only the
+job summary and uploads reports; it posts no PR comment and runs no privileged
+workflow against PR code or artifacts. Coverage comparison/publishing needs its
+own reviewed trust boundary in #96.
+
+Scope labels describe the checked-in coverage configuration. Backend XML totals
+are read from coverage.py; the renderer does not reconstruct the configured
+source/omit rules from XML. Update the scope label/documentation whenever those
+rules change. Frontend report filenames must match its two-file documented scope.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -20,8 +20,9 @@ CI remains authoritative when hooks are not installed.
 
 Coverage measures executable code under backend/app, excluding tests. Migration
 subprocesses and browser behavior are verified separately; the report does not
-measure a complete ecommerce product. The initial measured coverage is 89.4%.
-CI retains coverage XML and dependency-audit JSON artifacts for 14 days.
+measure a complete ecommerce product. See [coverage reports](coverage.md) for current run summaries, exact frontend
+scope and thresholds. CI retains browsable HTML, raw coverage and dependency-audit
+JSON artifacts for 14 days.
 
 The dependency audit runs for PRs, main pushes, weekly, and on manual dispatch.
 It audits development dependencies too. A failure must be investigated: dependency

--- a/scripts/coverage_summary.py
+++ b/scripts/coverage_summary.py
@@ -1,0 +1,140 @@
+"""Render existing coverage reports for read-only Actions job summaries."""
+
+import argparse
+import os
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+MAX_REPORT_BYTES = 5_000_000
+SCOPES = {
+    "backend": (
+        (
+            "backend/app; excludes app/tests. Migration subprocesses and browser tests "
+            "are separate evidence, not included in this measurement."
+        ),
+        "85% combined line/branch coverage (coverage.py); no separate line/branch gate.",
+    ),
+    "frontend": (
+        (
+            "Only src/lib/catalog.ts and src/lib/session.ts. This is NOT whole-frontend "
+            "coverage; components, routes and all other files are outside this scope."
+        ),
+        "95% statements, 90% branches, 100% functions and 95% lines (Vitest).",
+    ),
+}
+
+
+def counts(covered, total):
+    covered, total = int(covered), int(total)
+    if not 0 <= covered <= total:
+        raise ValueError("Invalid coverage counts")
+    return covered, total
+
+
+def parse_report(kind, report):
+    if report.stat().st_size > MAX_REPORT_BYTES:
+        raise ValueError("Coverage report exceeds size limit")
+    text = report.read_text(encoding="utf-8")
+    if kind == "backend":
+        root = ET.fromstring(text)
+        if root.tag != "coverage":
+            raise ValueError("Expected coverage XML")
+        return {
+            "Lines": counts(root.attrib["lines-covered"], root.attrib["lines-valid"]),
+            "Branches": counts(
+                root.attrib["branches-covered"], root.attrib["branches-valid"]
+            ),
+        }
+    totals = dict.fromkeys(("LH", "LF", "BRH", "BRF"), 0)
+    files = []
+    for record in text.split("end_of_record"):
+        fields = dict(line.split(":", 1) for line in record.splitlines() if ":" in line)
+        if not fields:
+            continue
+        files.append(fields["SF"])
+        # Require explicit totals, including zero, rather than inventing coverage.
+        for field in totals:
+            totals[field] += int(fields[field])
+        counts(fields["LH"], fields["LF"])
+        counts(fields["BRH"], fields["BRF"])
+    if sorted(files) != ["src/lib/catalog.ts", "src/lib/session.ts"]:
+        raise ValueError("Frontend report does not match the documented measured scope")
+    return {
+        "Lines": counts(totals["LH"], totals["LF"]),
+        "Branches": counts(totals["BRH"], totals["BRF"]),
+    }
+
+
+def render(kind, report, outcome, artifact_url="", revision="local"):
+    if not re.fullmatch(r"local|[0-9a-f]{7,40}", revision):
+        raise ValueError("Invalid tested revision")
+    if artifact_url and not re.fullmatch(
+        r"https://github\.com/[\w.-]+/[\w.-]+/actions/runs/\d+/artifacts/\d+",
+        artifact_url,
+    ):
+        raise ValueError("Invalid artifact URL")
+    scope, gate = SCOPES[kind]
+    lines = [
+        f"## {kind.title()} coverage",
+        "",
+        f"Tested revision: `{revision}`.",
+        "",
+        f"**Measured scope:** {scope}",
+        "",
+        f"**Existing gates:** {gate}",
+        f"**Test/coverage step outcome:** {outcome}. This reporter does not replace the test gates.",
+        "",
+    ]
+    valid = True
+    try:
+        metrics = parse_report(kind, report)
+        lines.extend(
+            ["| Metric | Covered / measured | Coverage |", "| --- | --- | --- |"]
+        )
+        for name, (covered, total) in metrics.items():
+            percentage = (
+                f"{covered / total:.1%}"
+                if total
+                else "N/A (no measured branches/lines)"
+            )
+            lines.append(f"| {name} | {covered} / {total} | {percentage} |")
+    except (OSError, ValueError, KeyError, ET.ParseError):
+        valid = False
+        lines.append(
+            "**Coverage unavailable:** report missing, malformed or outside the expected scope. No percentage or pass is inferred."
+        )
+    lines.extend(
+        [
+            "",
+            f"[Download HTML and raw reports]({artifact_url}) (14-day retention)."
+            if artifact_url
+            else "Artifact unavailable; inspect the report-upload step.",
+            "",
+            "Coverage supports review; it does not establish test quality or whole-product correctness.",
+        ]
+    )
+    return "\n".join(lines) + "\n", valid
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kind", choices=SCOPES, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument(
+        "--outcome",
+        choices=["success", "failure", "cancelled", "skipped"],
+        required=True,
+    )
+    parser.add_argument("--artifact-url", default="")
+    parser.add_argument("--revision", default=os.environ.get("GITHUB_SHA", "local"))
+    args = parser.parse_args()
+    summary, valid = render(
+        args.kind, args.report, args.outcome, args.artifact_url, args.revision
+    )
+    print(summary, end="")
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_coverage_summary.py
+++ b/scripts/tests/test_coverage_summary.py
@@ -1,0 +1,79 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "coverage_summary", Path(__file__).parents[1] / "coverage_summary.py"
+)
+coverage = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(coverage)
+
+
+class CoverageSummaryTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.report = Path(self.directory.name) / "report"
+
+    def test_backend_counts_and_failed_gate_are_not_conflated(self):
+        self.report.write_text(
+            '<coverage lines-covered="8" lines-valid="10" branches-covered="1" branches-valid="4"/>'
+        )
+        text, valid = coverage.render("backend", self.report, "failure")
+        self.assertTrue(valid)
+        self.assertIn("8 / 10 | 80.0%", text)
+        self.assertIn("1 / 4 | 25.0%", text)
+        self.assertIn("outcome:** failure", text)
+        self.assertIn("85% combined", text)
+
+    def test_frontend_aggregates_counts_not_percentages_and_states_scope(self):
+        self.report.write_text(
+            "SF:src/lib/catalog.ts\nLH:1\nLF:1\nBRH:0\nBRF:0\nend_of_record\nSF:src/lib/session.ts\nLH:1\nLF:9\nBRH:0\nBRF:0\nend_of_record\n"
+        )
+        text, valid = coverage.render(
+            "frontend",
+            self.report,
+            "success",
+            "https://github.com/owner/repo/actions/runs/1/artifacts/2",
+            "a" * 40,
+        )
+        self.assertTrue(valid)
+        self.assertIn("2 / 10 | 20.0%", text)
+        self.assertIn("N/A", text)
+        self.assertIn("NOT whole-frontend", text)
+        self.assertIn("Download HTML and raw reports", text)
+
+    def test_missing_malformed_negative_and_impossible_reports_are_unavailable(self):
+        for content in [
+            None,
+            "not XML",
+            "<coverage/>",
+            '<coverage lines-covered="-1" lines-valid="3"/>',
+            '<coverage lines-covered="4" lines-valid="3"/>',
+        ]:
+            with self.subTest(content=content):
+                if content is not None:
+                    self.report.write_text(content)
+                text, valid = coverage.render("backend", self.report, "failure")
+                self.assertFalse(valid)
+                self.assertIn("Coverage unavailable", text)
+                self.assertNotIn("| Lines |", text)
+
+    def test_frontend_wrong_scope_and_missing_branch_totals_are_rejected(self):
+        for content in [
+            "SF:src/other.ts\nLH:1\nLF:1\nBRH:0\nBRF:0\nend_of_record",
+            "SF:src/lib/catalog.ts\nLH:1\nLF:1\nend_of_record",
+        ]:
+            self.report.write_text(content)
+            self.assertFalse(coverage.render("frontend", self.report, "success")[1])
+
+    def test_oversized_reports_and_untrusted_summary_metadata_are_rejected(self):
+        self.report.write_text("x" * (coverage.MAX_REPORT_BYTES + 1))
+        self.assertFalse(coverage.render("backend", self.report, "failure")[1])
+        with self.assertRaises(ValueError):
+            coverage.render(
+                "backend", self.report, "success", "https://example.com/report)"
+            )
+        with self.assertRaises(ValueError):
+            coverage.render("backend", self.report, "success", revision="`injected`")


### PR DESCRIPTION
## Summary
Publish readable Actions coverage summaries with measured scope, line/branch counts, existing gate outcomes and downloadable HTML reports. Missing or malformed reports explicitly fail reporting; existing coverage scope and thresholds remain unchanged.

## Issue
Closes #95. Refs #57; base comparison and broader frontend measurement remain #96 and #97.

## Acceptance criteria
- [x] Scoped line/branch summaries preserve test outcomes and explain unavailable reports.
- [x] Backend HTML/XML and frontend HTML/LCOV uploads run after failures with 14-day retention.
- [x] Parser success/error tests and local reproduction documentation are included.

## Testing
Tested head `9f98483dcc3c500964a9e129b48fde43f98d30cd`; rebase range-diff unchanged. Script suite: 75 passed, including five report tests; Ruff and formatting checks passed. Backend: 98 passed, two PostgreSQL-only skips, combined coverage 92.68%; frontend: 55 passed and 100% for the existing two-file scope. Local HTML entrypoints verified.

Deliberately restricted backend tests failed the unchanged 85% gate at 76.83%; measuring an untested frontend utility failed its unchanged gates. Neither experiment changed tracked configuration. Missing-report CLI exited 1 with explicit unavailable output. Actual CI archives verified: backend coverage.xml + htmlcov/index.html; frontend lcov.info + lcov-report/index.html. Backend/quality/audit/script CI passed. Browser CI failed four image-loading assertions (35 passed, two skipped), tracked by the separate image fix #98; no rerun requested. This PR waits for that fix and then a fresh rebase/CI/review.

## Review
Self-review and historical preflight found no blocking findings: read-only workflow permissions, quoted metadata, bounded report parsing, accurate scope labels and failure paths checked. [Current-head Codex review](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/99#issuecomment-5648400972) completed clean; [CI](https://github.com/youneshenniwrites/fastapi-next-ecommerce/actions/runs/34716262225) has the image failures noted above.

## Final verification
Updated head `10771a3d6e` includes merged image fix #100. All CI passed and fresh Codex review was clean: https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/99#issuecomment-5652541270. Merged as `5656319`; earlier image failures above are historical.
