### PR TITLE
fix(images): backport upstream disconnected-client fix

### DIFF
--- a/.agents/skills/preflight-review/references/lessons.md
+++ b/.agents/skills/preflight-review/references/lessons.md
@@ -65,3 +65,11 @@ one hidden after mount; do not assume a visibility event always precedes setup.
 Prefer the installed Next.js documentation and framework-managed reads/actions to
 another client cache or polling mechanism. These lessons constrain behavior, not a
 requirement to preserve the old cart implementation.
+
+## Dependency backports — PR 100
+
+For an idempotent multi-part patch, require the complete patched form as well as
+its verified original source. Reversing independent edits can accidentally accept
+half-applied imports/bodies that leave runtime names undefined. Test each partial
+state and reject it before writing either distribution file
+([PR #100](https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/100#discussion_r3997433244)).

--- a/docs/framework-agent-guidance.md
+++ b/docs/framework-agent-guidance.md
@@ -58,3 +58,26 @@ behavior and its necessary tests together; generated files may make a legitimate
 commit larger. After relevant checks and staged-diff review, push verified
 milestones regularly within the user's existing authorization. Do not force-push
 or weaken CI to meet this cadence. Re-request current-head review after changes.
+
+### Temporary Next.js image backport (#98)
+
+Next.js 16.3.4's standalone image optimizer can permanently hang an uncached
+variant when the first client disconnects. This caused repeated browser CI
+failures after navigation. See [upstream issue #96538](https://github.com/vercel/next.js/issues/96538)
+and the accepted [fix #98168](https://github.com/vercel/next.js/pull/98168).
+Stable 16.3.5 still lacks that fix as verified on 12 September 2026.
+
+`frontend/scripts/patch-next-image.mjs` applies the response-socket-only backport
+after `npm ci` and before `npm run build`. It preserves the request socket for
+protocol/address handling and the response-body size limit. Both distributed
+module formats are checked against exact 16.3.4 source hashes before either is
+written; unexpected versions/content fail the command. It is idempotent and
+changes no application code or image assertions. `npm test` checks disconnected
+and live callers, request metadata, size limits and the patch guards.
+
+When upgrading Next.js, verify the stable release contains upstream #98168, run
+the disconnected-caller regression against it, then remove the backport script
+and its install/build hooks in the same PR. Never simply loosen the version/hash
+guards. Keep the runtime regression; adapt its internal API if upstream changes.
+The standalone production build copies the patched dependency. Vercel's hosted
+image optimization is separate from this local/standalone optimizer.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ecommerce-storefront",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@hookform/resolvers": "5.9.1",
         "class-variance-authority": "0.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,12 +13,14 @@
     "start": "node .next/standalone/server.js",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "vitest run --coverage",
+    "test": "node --test scripts/patch-next-image.test.mjs && vitest run --coverage",
     "test:e2e": "playwright test",
     "api:generate": "openapi-typescript openapi.json -o src/lib/api/schema.d.ts",
     "api:check": "npm run api:generate && git diff --exit-code -- openapi.json src/lib/api/schema.d.ts",
     "format:check": "prettier --check .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "postinstall": "node scripts/patch-next-image.mjs",
+    "prebuild": "node scripts/patch-next-image.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "5.9.1",

--- a/frontend/scripts/patch-next-image.mjs
+++ b/frontend/scripts/patch-next-image.mjs
@@ -74,7 +74,11 @@ export function patchNextImage(nextDirectory) {
     }
     const reverted = source.replace(after, before);
     const restored = esm ? reverted.replace(newImport, oldImport) : reverted;
-    if (sha256(restored) !== file.hash) {
+    const completePatch = restored.replace(before, after);
+    const expected = esm
+      ? completePatch.replace(oldImport, newImport)
+      : completePatch;
+    if (sha256(restored) !== file.hash || source !== expected) {
       throw new Error(
         `Unexpected Next source hash: ${file.path}; refusing to patch`,
       );

--- a/frontend/scripts/patch-next-image.mjs
+++ b/frontend/scripts/patch-next-image.mjs
@@ -1,0 +1,91 @@
+import process from "node:process";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Temporary backport of https://github.com/vercel/next.js/pull/98168.
+// Keep the request socket (protocol/address); detach only the response socket.
+const original = `        const mocked = CALL({
+            url: href,
+            method,
+            socket: _req.socket,
+            maximumResponseBody
+        });`;
+const replacement = `        const mocked = {
+            req: new REQUEST({
+                url: href,
+                method,
+                headers: {},
+                socket: _req.socket
+            }),
+            res: new RESPONSE({ maximumResponseBody })
+        };`;
+const files = [
+  {
+    path: "dist/server/image-optimizer.js",
+    hash: "e9dae780db97eb11cbed0c5b1c872dc249fedfe9aab50132b43e5b54d34b47a8",
+    call: "(0, _mockrequest.createRequestResponseMocks)",
+    request: "_mockrequest.MockedRequest",
+    response: "_mockrequest.MockedResponse",
+  },
+  {
+    path: "dist/esm/server/image-optimizer.js",
+    hash: "3ebd7bad4de250400b0f347cae2a17ab7ec03722914f3736260366df457e27d2",
+    call: "createRequestResponseMocks",
+    request: "MockedRequest",
+    response: "MockedResponse",
+  },
+];
+const oldImport =
+  "import { createRequestResponseMocks } from './lib/mock-request';";
+const newImport =
+  "import { MockedRequest, MockedResponse } from './lib/mock-request';";
+const sha256 = (source) => createHash("sha256").update(source).digest("hex");
+
+export function patchNextImage(nextDirectory) {
+  const { version } = JSON.parse(
+    readFileSync(join(nextDirectory, "package.json")),
+  );
+  if (version !== "16.3.4") {
+    throw new Error(
+      `Review/remove the Next image backport before using Next ${version}`,
+    );
+  }
+  // Validate both files before writing either; allow only exact original or
+  // exactly reversible patched content, so repeat installs are idempotent.
+  const updates = files.map((file) => {
+    const path = join(nextDirectory, file.path);
+    const source = readFileSync(path, "utf8");
+    const before = original.replace("CALL", file.call);
+    const after = replacement
+      .replace("REQUEST", file.request)
+      .replace("RESPONSE", file.response);
+    const esm = file.path.includes("/esm/");
+    if (sha256(source) === file.hash) {
+      if (source.split(before).length !== 2)
+        throw new Error(`Unexpected patch target: ${file.path}`);
+      const patched = source.replace(before, after);
+      return {
+        path,
+        source: esm ? patched.replace(oldImport, newImport) : patched,
+      };
+    }
+    const reverted = source.replace(after, before);
+    const restored = esm ? reverted.replace(newImport, oldImport) : reverted;
+    if (sha256(restored) !== file.hash) {
+      throw new Error(
+        `Unexpected Next source hash: ${file.path}; refusing to patch`,
+      );
+    }
+    return null;
+  });
+  for (const update of updates)
+    if (update) writeFileSync(update.path, update.source);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const require = createRequire(import.meta.url);
+  patchNextImage(dirname(require.resolve("next/package.json")));
+}

--- a/frontend/scripts/patch-next-image.test.mjs
+++ b/frontend/scripts/patch-next-image.test.mjs
@@ -89,6 +89,34 @@ test("patch is idempotent and rejects unexpected versions or source", () => {
     }
     patchNextImage(fixture);
     patchNextImage(fixture);
+    const esmPath = join(fixture, "dist/esm/server/image-optimizer.js");
+    const esmPatched = readFileSync(esmPath, "utf8");
+    const newImport =
+      "import { MockedRequest, MockedResponse } from './lib/mock-request';";
+    const oldImport =
+      "import { createRequestResponseMocks } from './lib/mock-request';";
+    // Either half of the ESM edit leaves identifiers undefined at runtime.
+    const bodyOnly = esmPatched.replace(newImport, oldImport);
+    const importOnly = esmPatched.replace(
+      / {8}const mocked = \{\n {12}req: new MockedRequest\([\s\S]*?\n {8}\};/,
+      `        const mocked = createRequestResponseMocks({
+            url: href,
+            method,
+            socket: _req.socket,
+            maximumResponseBody
+        });`,
+    );
+    assert.notEqual(bodyOnly, esmPatched);
+    assert.notEqual(importOnly, esmPatched);
+    for (const partial of [bodyOnly, importOnly]) {
+      writeFileSync(esmPath, partial);
+      assert.throws(
+        () => patchNextImage(fixture),
+        /Unexpected Next source hash/,
+      );
+      assert.equal(readFileSync(esmPath, "utf8"), partial);
+    }
+    writeFileSync(esmPath, esmPatched);
     const target = join(fixture, "dist/server/image-optimizer.js");
     const content = readFileSync(target, "utf8");
     writeFileSync(target, content + "\n// unexpected modification\n");

--- a/frontend/scripts/patch-next-image.test.mjs
+++ b/frontend/scripts/patch-next-image.test.mjs
@@ -1,0 +1,108 @@
+import { setTimeout, clearTimeout } from "node:timers";
+import assert from "node:assert/strict";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { patchNextImage } from "./patch-next-image.mjs";
+const require = createRequire(import.meta.url);
+const nextDirectory = dirname(require.resolve("next/package.json"));
+patchNextImage(nextDirectory);
+const { fetchInternalImage } = require("next/dist/server/image-optimizer");
+const { serveStatic } = require("next/dist/server/serve-static");
+const photo = new URL("../public/photos/headphones.webp", import.meta.url);
+for (const disconnected of [false, true]) {
+  test(`local image settles with ${disconnected ? "disconnected" : "live"} caller`, async () => {
+    const socket = new Socket();
+    socket.encrypted = true;
+    Object.defineProperty(socket, "remoteAddress", { value: "192.0.2.1" });
+    if (disconnected) socket.destroy();
+    let timer;
+    try {
+      const result = await Promise.race([
+        fetchInternalImage(
+          "/photos/headphones.webp",
+          { method: "HEAD", socket },
+          {},
+          1000000,
+          async (request, response) => {
+            assert.equal(request.socket, socket);
+            assert.equal(request.socket.encrypted, true);
+            assert.equal(request.socket.remoteAddress, "192.0.2.1");
+            assert.equal(request.method, "GET");
+            assert.equal(response.socket, null);
+            await serveStatic(request, response, photo.pathname);
+          },
+        ),
+        new Promise((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  "Internal image fetch hung after caller disconnected",
+                ),
+              ),
+            2000,
+          );
+        }),
+      ]);
+      assert.deepEqual(result.buffer, readFileSync(photo));
+    } finally {
+      clearTimeout(timer);
+      socket.destroy();
+    }
+  });
+}
+test("internal image still enforces maximum response body", async () => {
+  await assert.rejects(
+    fetchInternalImage(
+      "/photos/headphones.webp",
+      { method: "GET" },
+      {},
+      1,
+      async (_request, response) => {
+        response.end(readFileSync(photo));
+      },
+    ),
+    (error) => error.statusCode === 413,
+  );
+});
+test("patch is idempotent and rejects unexpected versions or source", () => {
+  const fixture = mkdtempSync(join(tmpdir(), "next-image-patch-"));
+  try {
+    cpSync(join(nextDirectory, "package.json"), join(fixture, "package.json"));
+    for (const relative of [
+      "dist/server/image-optimizer.js",
+      "dist/esm/server/image-optimizer.js",
+    ]) {
+      cpSync(join(nextDirectory, relative), join(fixture, relative), {
+        recursive: true,
+      });
+    }
+    patchNextImage(fixture);
+    patchNextImage(fixture);
+    const target = join(fixture, "dist/server/image-optimizer.js");
+    const content = readFileSync(target, "utf8");
+    writeFileSync(target, content + "\n// unexpected modification\n");
+    assert.throws(() => patchNextImage(fixture), /Unexpected Next source hash/);
+    assert.equal(
+      readFileSync(target, "utf8"),
+      content + "\n// unexpected modification\n",
+    );
+    writeFileSync(
+      join(fixture, "package.json"),
+      JSON.stringify({ version: "16.3.5" }),
+    );
+    assert.throws(() => patchNextImage(fixture), /Review\/remove/);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
A client disconnect during a cold local image request can leave that image variant pending for every subsequent request until the standalone server restarts. Backport the accepted Next.js response-socket fix without changing the installed framework version or weakening browser assertions.

## Issue
Closes #98. Scope is the temporary upstream backport, reproducible install/build hooks, regression checks and removal instructions.

## Acceptance criteria
- [x] Internal response no longer depends on the disconnected caller; request socket metadata and body limits remain intact.
- [x] Exact Next 16.3.4 version and complete CJS/ESM source hashes are validated before writes; repeated installation is safe.
- [x] Provenance and stable-release removal procedure documented.
- [x] Production browser CI passes.

## Testing
- Reproduced original defect using the real photo through installed `fetchInternalImage`/`serveStatic`: live socket completes in 5 ms; destroyed socket remains pending after 8 seconds.
- Four Node regressions pass: live/disconnected socket, request protocol/address and HEAD normalization, body-size enforcement, idempotence and unexpected version/source rejection.
- Existing 55 unit tests pass; lint passes; production webpack build passes locally.
- Desktop/mobile catalog browser checks: 12 passed, 2 inapplicable mobile-only skips, using isolated fixture ports. Standard CI production build/browser checks remain enabled.

## Review
Implementation review: self-review of the full diff against upstream #98168 and repository preflight lessons. No test expectations were relaxed. Owner: @youneshenniwrites. Fresh Codex review approved `d56031d458` and all CI passed before merge: https://github.com/youneshenniwrites/fastapi-next-ecommerce/pull/100#issuecomment-5652521034. Merged as `edb6604`.

## Compatibility
Official fix: https://github.com/vercel/next.js/pull/98168 (merged); original report: https://github.com/vercel/next.js/issues/96538. Latest stable 16.3.5 still lacks this fix, verified from its tagged source. The backport is deliberately version/hash guarded and must be removed or reassessed before upgrading Next.js. Both distributed module formats are patched; standalone builds include the patched dependency. Vercel-hosted image optimization is separate.
